### PR TITLE
[arch] cc-judge v1 interface stubs (not for merge)

### DIFF
--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -1,0 +1,49 @@
+// CLI entrypoints: `cc-judge run` and `cc-judge score`.
+// Built on yargs. Exit codes: 0 all-pass, 1 any-fail, 2 fatal.
+// Non-interactive by default (spec Goal 12, non-goal #24).
+
+import type { Effect } from "effect";
+
+// Return type is a process exit code. Effect error channel is `never`: fatal errors
+// map to exit 2 before the Effect returns.
+export type CliExitCode = 0 | 1 | 2;
+
+export declare function main(argv: ReadonlyArray<string>): Effect.Effect<CliExitCode, never, never>;
+
+// Subcommand entrypoints. Called by `main` after yargs parsing.
+export declare function runCommand(args: RunCliArgs): Effect.Effect<CliExitCode, never, never>;
+export declare function scoreCommand(args: ScoreCliArgs): Effect.Effect<CliExitCode, never, never>;
+
+export interface RunCliArgs {
+  readonly scenarioPath: string;
+  readonly runtime: "docker" | "subprocess";
+  readonly image?: string;
+  readonly bin?: string;
+  readonly judge: string;
+  readonly judgeBackend: string;
+  readonly runs: number;
+  readonly scenarioIds?: ReadonlyArray<string>;
+  readonly results: string;
+  readonly githubComment?: number;
+  readonly githubCommentArtifactUrl?: string;
+  readonly concurrency: number;
+  readonly logLevel: "debug" | "info" | "warn" | "error";
+  readonly totalTimeoutMs?: number;
+  readonly emitBraintrust: boolean;
+  readonly emitPromptfoo?: string;
+}
+
+export interface ScoreCliArgs {
+  readonly tracesPath: string;
+  readonly traceFormat: "canonical" | "otel";
+  readonly judge: string;
+  readonly judgeBackend: string;
+  readonly results: string;
+  readonly githubComment?: number;
+  readonly githubCommentArtifactUrl?: string;
+  readonly concurrency: number;
+  readonly logLevel: "debug" | "info" | "warn" | "error";
+  readonly totalTimeoutMs?: number;
+  readonly emitBraintrust: boolean;
+  readonly emitPromptfoo?: string;
+}

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,0 +1,3 @@
+export * from "./opts.js";
+export * from "./pipeline.js";
+export * from "./cli.js";

--- a/src/app/opts.ts
+++ b/src/app/opts.ts
@@ -1,0 +1,30 @@
+// Options surfaces for the two SDK entrypoints.
+// Shared fields live in a common base; run/score specialize.
+
+import type { JudgeBackend } from "../judge/index.js";
+import type { ObservabilityEmitter } from "../emit/observability.js";
+import type { AgentRunner } from "../runner/index.js";
+import type { LogLevel } from "../core/types.js";
+import type { TraceFormat } from "../emit/trace-adapter.js";
+
+export interface SharedOpts {
+  readonly judge?: JudgeBackend;
+  readonly resultsDir?: string;
+  readonly runsPerScenario?: number;
+  readonly concurrency?: number;
+  readonly logLevel?: LogLevel;
+  readonly totalTimeoutMs?: number;
+  readonly emitters?: ReadonlyArray<ObservabilityEmitter>;
+  readonly githubComment?: number;
+  readonly githubCommentArtifactUrl?: string;
+  readonly abortSignal?: AbortSignal;
+}
+
+export interface RunOpts extends SharedOpts {
+  readonly runner?: AgentRunner;
+  readonly scenarioIdFilter?: ReadonlyArray<string>;
+}
+
+export interface ScoreOpts extends SharedOpts {
+  readonly traceFormat?: TraceFormat;
+}

--- a/src/app/pipeline.ts
+++ b/src/app/pipeline.ts
@@ -1,0 +1,28 @@
+// Pipeline orchestration: composes runner + judge + report + observability.
+// Public SDK entrypoints. Invariant #3: error channel is `never` — all internal
+// failures fold into per-run RunRecords; the pipeline always produces a Report.
+
+import type { Effect } from "effect";
+import type { Report, Scenario, Trace } from "../core/schema.js";
+import type { RunOpts, ScoreOpts } from "./opts.js";
+
+// Run one scenario (runsPerScenario applies). Default runner: DockerRunner (image required).
+// Default judge: AnthropicJudgeBackend.
+export declare function runScenario(
+  scenario: Scenario,
+  opts?: RunOpts,
+): Effect.Effect<Report, never, never>;
+
+// Run a scenario set. Emits per-run RunRecords to results.jsonl as they complete,
+// then writes summary.md + details/*.yaml at close.
+export declare function runScenarios(
+  scenarios: ReadonlyArray<Scenario>,
+  opts?: RunOpts,
+): Effect.Effect<Report, never, never>;
+
+// Score already-executed traces. No runner invoked; same judge + report path.
+// RunRecord.source === "trace" on every emitted record.
+export declare function scoreTraces(
+  traces: ReadonlyArray<Trace>,
+  opts?: ScoreOpts,
+): Effect.Effect<Report, never, never>;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,55 @@
+// Tagged error classes for every public Effect error channel.
+// Principle 3: errors are typed, not thrown. Every cause is a discriminated tag.
+
+import { Data } from "effect";
+import type { ScenarioId } from "./types.js";
+
+export class LoadError extends Data.TaggedError("LoadError")<{
+  readonly cause: LoadErrorCause;
+}> {}
+
+export type LoadErrorCause =
+  | { readonly _tag: "FileNotFound"; readonly path: string }
+  | { readonly _tag: "GlobNoMatches"; readonly pattern: string }
+  | { readonly _tag: "ParseFailure"; readonly path: string; readonly message: string }
+  | { readonly _tag: "SchemaInvalid"; readonly path: string; readonly errors: ReadonlyArray<string> }
+  | { readonly _tag: "DuplicateId"; readonly id: ScenarioId; readonly paths: readonly [string, string] };
+
+export class AgentStartError extends Data.TaggedError("AgentStartError")<{
+  readonly scenarioId: ScenarioId;
+  readonly cause: AgentStartErrorCause;
+}> {}
+
+export type AgentStartErrorCause =
+  | { readonly _tag: "ImageMissing"; readonly image: string }
+  | { readonly _tag: "ContainerStartFailed"; readonly message: string }
+  | { readonly _tag: "BinaryNotFound"; readonly path: string }
+  | { readonly _tag: "WorkspaceSetupFailed"; readonly message: string };
+
+export class AgentRunTimeoutError extends Data.TaggedError("AgentRunTimeoutError")<{
+  readonly scenarioId: ScenarioId;
+  readonly turnIndex: number;
+  readonly timeoutMs: number;
+}> {}
+
+export class TotalTimeoutExceeded extends Data.TaggedError("TotalTimeoutExceeded")<{
+  readonly totalTimeoutMs: number;
+  readonly completedRuns: number;
+}> {}
+
+export class TraceDecodeError extends Data.TaggedError("TraceDecodeError")<{
+  readonly cause: TraceDecodeCause;
+}> {}
+
+export type TraceDecodeCause =
+  | { readonly _tag: "UnknownFormat"; readonly path: string }
+  | { readonly _tag: "SchemaInvalid"; readonly path: string; readonly errors: ReadonlyArray<string> };
+
+export class PublishError extends Data.TaggedError("PublishError")<{
+  readonly cause: PublishErrorCause;
+}> {}
+
+export type PublishErrorCause =
+  | { readonly _tag: "GhCliMissing" }
+  | { readonly _tag: "GhCliFailed"; readonly exitCode: number; readonly stderr: string }
+  | { readonly _tag: "BodyTooLarge"; readonly chars: number; readonly limit: number };

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./errors.js";
+export * from "./schema.js";
+export * from "./scenario.js";

--- a/src/core/scenario.ts
+++ b/src/core/scenario.ts
@@ -1,0 +1,18 @@
+// Scenario loader: TS import + YAML decoder + duplicate-id enforcement.
+// Data boundary: bytes-on-disk -> validated Scenario[] (schema-decoded).
+
+import type { Effect } from "effect";
+import type { LoadError } from "./errors.js";
+import type { Scenario } from "./schema.js";
+
+export interface ScenarioLoader {
+  // Resolve path/glob to files, decode each (TS or YAML), enforce id uniqueness across the set.
+  // Aborts with LoadError.DuplicateId naming both offending paths; the CLI maps this to exit 2.
+  loadFromPath(pathOrGlob: string): Effect.Effect<ReadonlyArray<Scenario>, LoadError, never>;
+
+  // Decode a single YAML source into a Scenario (schema-validated at the boundary).
+  // YAML callers cannot serialize function-shaped deterministic checks (spec Q4.2 recommended A).
+  loadFromYaml(source: string, originPath: string): Effect.Effect<Scenario, LoadError, never>;
+}
+
+export declare const scenarioLoader: ScenarioLoader;

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,0 +1,120 @@
+// TypeBox schemas at every data boundary.
+// Principle 2: schemas where data enters, types inside.
+// All runtime decoding (YAML -> Scenario, JSON -> JudgeResult, JSONL -> Trace) routes through here.
+
+import type { Static, TSchema } from "@sinclair/typebox";
+import type {
+  DeterministicCtx,
+  Issue,
+  IssueSeverity,
+  RunNumber,
+  RunSource,
+  ScenarioId,
+  TraceId,
+  Turn,
+  WorkspaceDiff,
+  WorkspaceFile,
+} from "./types.js";
+
+// Schemas below are declared but not initialized. Implement-staff wires the
+// TypeBox calls after /safer:setup installs @sinclair/typebox.
+
+export declare const ScenarioIdSchema: TSchema;
+export declare const TraceIdSchema: TSchema;
+export declare const IssueSeveritySchema: TSchema;
+export declare const WorkspaceFileSchema: TSchema;
+export declare const WorkspaceDiffSchema: TSchema;
+export declare const TurnSchema: TSchema;
+export declare const IssueSchema: TSchema;
+
+export interface Scenario {
+  readonly id: ScenarioId;
+  readonly name: string;
+  readonly description: string;
+  readonly setupPrompt: string;
+  readonly followUps?: ReadonlyArray<string>;
+  readonly workspace?: ReadonlyArray<WorkspaceFile>;
+  readonly timeoutMs?: number;
+  readonly expectedBehavior: string;
+  readonly validationChecks: ReadonlyArray<string>;
+  readonly deterministicPassCheck?: (ctx: DeterministicCtx) => boolean;
+  readonly deterministicFailCheck?: (ctx: DeterministicCtx) => boolean;
+  readonly metadata?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export declare const ScenarioSchema: TSchema;
+export declare const ScenarioYamlSchema: TSchema;
+
+export interface JudgeResult {
+  readonly pass: boolean;
+  readonly reason: string;
+  readonly issues: ReadonlyArray<Issue>;
+  readonly overallSeverity: IssueSeverity | null;
+  readonly judgeConfidence?: number;
+  readonly retryCount: number;
+}
+
+export declare const JudgeResultSchema: TSchema;
+
+export interface RunRecord {
+  readonly source: RunSource;
+  readonly scenarioId: ScenarioId;
+  readonly runNumber: RunNumber;
+  readonly modelName: string;
+  readonly judgeModel: string;
+  readonly startedAt: string;
+  readonly latencyMs: number;
+  readonly pass: boolean;
+  readonly reason: string;
+  readonly issues: ReadonlyArray<Issue>;
+  readonly overallSeverity: IssueSeverity | null;
+  readonly judgeConfidence: number | null;
+  readonly retryCount: number;
+  readonly toolCallCount: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly transcriptPath: string;
+  readonly workspaceDiffSummary: { readonly changed: number; readonly added: number; readonly removed: number };
+  readonly traceId?: TraceId;
+}
+
+export declare const RunRecordSchema: TSchema;
+
+export interface ReportSummary {
+  readonly total: number;
+  readonly passed: number;
+  readonly failed: number;
+  readonly avgLatencyMs: number;
+}
+
+export interface Report {
+  readonly runs: ReadonlyArray<RunRecord>;
+  readonly summary: ReportSummary;
+  readonly artifactsDir?: string;
+}
+
+export declare const ReportSchema: TSchema;
+
+export interface Trace {
+  readonly traceId: TraceId;
+  readonly scenarioId?: ScenarioId;
+  readonly name: string;
+  readonly turns: ReadonlyArray<Turn>;
+  readonly workspaceDiff?: WorkspaceDiff;
+  readonly expectedBehavior: string;
+  readonly validationChecks: ReadonlyArray<string>;
+  readonly metadata?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export declare const TraceSchema: TSchema;
+
+// Promptfoo results shape is external contract; schema'd so adapter emits valid output.
+export declare const PromptfooResultsSchema: TSchema;
+
+// Static-type helpers (once schemas are initialized, Static<typeof X> == the interface above).
+export type ScenarioStatic = Static<typeof ScenarioSchema>;
+export type JudgeResultStatic = Static<typeof JudgeResultSchema>;
+export type RunRecordStatic = Static<typeof RunRecordSchema>;
+export type TraceStatic = Static<typeof TraceSchema>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,54 @@
+// Branded primitives and discriminated unions shared across modules.
+// Stubs only. Implement-staff provides runtime constructors after /safer:setup.
+
+import type { Brand } from "effect";
+
+export type ScenarioId = string & Brand.Brand<"ScenarioId">;
+export type TraceId = string & Brand.Brand<"TraceId">;
+export type RunNumber = number & Brand.Brand<"RunNumber">;
+
+export type IssueSeverity = "minor" | "significant" | "critical";
+
+export type RunSource = "scenario" | "trace";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type RuntimeKind = "docker" | "subprocess";
+
+export interface Issue {
+  readonly issue: string;
+  readonly severity: IssueSeverity;
+}
+
+export interface WorkspaceFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface WorkspaceFileChange {
+  readonly path: string;
+  readonly before: string | null;
+  readonly after: string | null;
+}
+
+export interface WorkspaceDiff {
+  readonly changed: ReadonlyArray<WorkspaceFileChange>;
+}
+
+export interface Turn {
+  readonly index: number;
+  readonly prompt: string;
+  readonly response: string;
+  readonly startedAt: string;
+  readonly latencyMs: number;
+  readonly toolCallCount: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+}
+
+export interface DeterministicCtx {
+  readonly transcript: string;
+  readonly diff: WorkspaceDiff;
+}

--- a/src/emit/index.ts
+++ b/src/emit/index.ts
@@ -1,0 +1,3 @@
+export * from "./report.js";
+export * from "./observability.js";
+export * from "./trace-adapter.js";

--- a/src/emit/observability.ts
+++ b/src/emit/observability.ts
@@ -1,0 +1,50 @@
+// ObservabilityEmitter interface + BraintrustEmitter + PromptfooEmitter.
+// Invariant #12: emission never changes verdict or exit code.
+// Spec Q-OBS-1 (A): array of emitters, each failure isolated.
+// Spec Q-OBS-2 (C): both per-run (streaming) and per-report (roll-up).
+
+import type { Effect } from "effect";
+import type { Report, RunRecord } from "../core/schema.js";
+
+export interface ObservabilityEvent {
+  readonly record: RunRecord;
+}
+
+export interface ObservabilityReport {
+  readonly report: Report;
+}
+
+export interface ObservabilityEmitter {
+  readonly name: string;
+
+  // Per-run streaming event. No-op implementations return Effect.void.
+  onRun(event: ObservabilityEvent): Effect.Effect<void, never, never>;
+
+  // Per-report roll-up. No-op implementations return Effect.void.
+  onReport(event: ObservabilityReport): Effect.Effect<void, never, never>;
+}
+
+export interface BraintrustEmitterOpts {
+  readonly project: string;
+  readonly apiKey: string;
+  readonly experimentName?: string;
+}
+
+export declare class BraintrustEmitter implements ObservabilityEmitter {
+  readonly name: "braintrust";
+  constructor(opts: BraintrustEmitterOpts);
+  onRun(event: ObservabilityEvent): Effect.Effect<void, never, never>;
+  onReport(event: ObservabilityReport): Effect.Effect<void, never, never>;
+}
+
+export interface PromptfooEmitterOpts {
+  // cc-judge writes a promptfoo-shaped results file. We do not pull promptfoo as a runtime dep.
+  readonly outputPath: string;
+}
+
+export declare class PromptfooEmitter implements ObservabilityEmitter {
+  readonly name: "promptfoo";
+  constructor(opts: PromptfooEmitterOpts);
+  onRun(event: ObservabilityEvent): Effect.Effect<void, never, never>;
+  onReport(event: ObservabilityReport): Effect.Effect<void, never, never>;
+}

--- a/src/emit/report.ts
+++ b/src/emit/report.ts
@@ -1,0 +1,29 @@
+// Report emitter: writes the summary.md + results.jsonl + details/*.yaml triple,
+// and optionally posts a GitHub comment.
+// Invariant: emission is idempotent (re-runs overwrite); emission never changes verdicts.
+
+import type { Effect } from "effect";
+import type { PublishError } from "../core/errors.js";
+import type { Report, RunRecord } from "../core/schema.js";
+
+export interface ReportEmitterOpts {
+  readonly resultsDir: string;
+  readonly githubComment?: number;
+  readonly githubCommentArtifactUrl?: string;
+}
+
+export interface ReportEmitter {
+  // Append one RunRecord line to results.jsonl and write details/<id>.<run>.yaml.
+  // Streaming: called after each run completes so scheduled jobs see partial output on timeout.
+  emitRun(record: RunRecord): Effect.Effect<void, never, never>;
+
+  // Emit the Report triple at pipeline close: summary.md + finalized results.jsonl + details/.
+  emitReport(report: Report): Effect.Effect<void, never, never>;
+
+  // Opt-in GitHub comment. Non-verdict: PublishError surfaces as a warning, never alters exit code.
+  // Spec Q5.2-B: if summary exceeds ~65k chars, post overall + count + githubCommentArtifactUrl;
+  // fall back to inline-truncation when the URL is absent.
+  publishGithubComment(report: Report): Effect.Effect<void, PublishError, never>;
+}
+
+export declare function makeReportEmitter(opts: ReportEmitterOpts): ReportEmitter;

--- a/src/emit/trace-adapter.ts
+++ b/src/emit/trace-adapter.ts
@@ -1,0 +1,20 @@
+// Trace format adapters: convert external trace formats into the canonical cc-judge Trace.
+// Spec Q-ONLINE-1 (A): canonical Trace + adapters. OTel adapter shipped in v1.
+// Invariant #6: unparseable traces fold into a critical-severity RunRecord; never crash the pipeline.
+
+import type { Effect } from "effect";
+import type { TraceDecodeError } from "../core/errors.js";
+import type { Trace } from "../core/schema.js";
+
+export type TraceFormat = "canonical" | "otel";
+
+export interface TraceAdapter {
+  readonly format: TraceFormat;
+  decode(source: string, originPath: string): Effect.Effect<Trace, TraceDecodeError, never>;
+}
+
+export declare const canonicalTraceAdapter: TraceAdapter;
+export declare const otelTraceAdapter: TraceAdapter;
+
+// Dispatch table keyed by --trace-format. Implement-staff wires the concrete adapters.
+export declare function getTraceAdapter(format: TraceFormat): TraceAdapter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,8 @@
+// cc-judge public surface. Every export here is an interface stub until
+// implement-staff fills in the bodies on the post-/safer:setup branch.
+
+export * from "./core/index.js";
+export * from "./runner/index.js";
+export * from "./judge/index.js";
+export * from "./emit/index.js";
+export * from "./app/index.js";

--- a/src/judge/index.ts
+++ b/src/judge/index.ts
@@ -1,0 +1,36 @@
+// JudgeBackend interface + bundled AnthropicJudgeBackend.
+// Responsibility: score (scenario, turns, diff?) into a JudgeResult.
+// Invariant #3: judge() error channel is `never`. Internal failures fold into a critical-severity result.
+
+import type { Effect } from "effect";
+import type { Turn, WorkspaceDiff } from "../core/types.js";
+import type { JudgeResult, Scenario } from "../core/schema.js";
+
+export interface JudgeInput {
+  readonly scenario: Scenario;
+  readonly turns: ReadonlyArray<Turn>;
+  readonly workspaceDiff?: WorkspaceDiff;
+  readonly abortSignal?: AbortSignal;
+}
+
+export interface JudgeBackend {
+  readonly name: string;
+
+  // Verdict is owned here. Internal errors (network, malformed structured output,
+  // retry exhaustion) fold into a JudgeResult with pass=false, overallSeverity="critical".
+  judge(input: JudgeInput): Effect.Effect<JudgeResult, never, never>;
+}
+
+export interface AnthropicJudgeBackendOpts {
+  // Spec assumption #13: default judge model is "claude-opus-4-7".
+  readonly model?: string;
+  readonly maxTurns?: number;
+  readonly perAttemptTimeoutMs?: number;
+  readonly retrySchedule?: ReadonlyArray<number>;
+}
+
+export declare class AnthropicJudgeBackend implements JudgeBackend {
+  readonly name: "anthropic";
+  constructor(opts?: AnthropicJudgeBackendOpts);
+  judge(input: JudgeInput): Effect.Effect<JudgeResult, never, never>;
+}

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -1,0 +1,72 @@
+// AgentRunner interface + bundled DockerRunner, SubprocessRunner.
+// Responsibility: execute one agent turn, capture workspace diff, tear down.
+// Invariant: stop() never fails (teardown is crash-only).
+
+import type { Effect } from "effect";
+import type {
+  AgentRunTimeoutError,
+  AgentStartError,
+} from "../core/errors.js";
+import type { RuntimeKind, Turn, WorkspaceDiff } from "../core/types.js";
+import type { Scenario } from "../core/schema.js";
+
+// Branded handle: opaque to callers, owned by the runner.
+export interface AgentHandle {
+  readonly __brand: "AgentHandle";
+  readonly kind: RuntimeKind;
+  readonly scenarioId: string;
+}
+
+export interface AgentRunner {
+  readonly kind: RuntimeKind;
+
+  // Boot the agent for a scenario (mount workspace, seed setupPrompt context, wait-for-ready).
+  start(scenario: Scenario): Effect.Effect<AgentHandle, AgentStartError, never>;
+
+  // Send one prompt, wait for terminal result/success (or timeout), return the populated Turn.
+  turn(
+    handle: AgentHandle,
+    prompt: string,
+    opts: { readonly timeoutMs: number },
+  ): Effect.Effect<Turn, AgentRunTimeoutError, never>;
+
+  // Snapshot the workspace delta relative to scenario.workspace.
+  diff(handle: AgentHandle): Effect.Effect<WorkspaceDiff, never, never>;
+
+  // Teardown. Invariant: never fails; internal errors are logged and swallowed.
+  stop(handle: AgentHandle): Effect.Effect<void, never, never>;
+}
+
+export interface DockerRunnerOpts {
+  // Spec Q-ARCH-2: no default. Caller must supply an image identifier.
+  // Docs recommend `ghcr.io/anthropics/claude-code:latest` as a reference.
+  readonly image: string;
+  readonly network?: "none" | "bridge";
+  readonly memoryMb?: number;
+  readonly cpus?: number;
+}
+
+export declare class DockerRunner implements AgentRunner {
+  readonly kind: "docker";
+  constructor(opts: DockerRunnerOpts);
+  start(scenario: Scenario): Effect.Effect<AgentHandle, AgentStartError, never>;
+  turn(h: AgentHandle, prompt: string, opts: { readonly timeoutMs: number }): Effect.Effect<Turn, AgentRunTimeoutError, never>;
+  diff(h: AgentHandle): Effect.Effect<WorkspaceDiff, never, never>;
+  stop(h: AgentHandle): Effect.Effect<void, never, never>;
+}
+
+export interface SubprocessRunnerOpts {
+  // Path to a local `claude` binary (spec assumption #4 — spike-proven in moltzap).
+  readonly bin: string;
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+export declare class SubprocessRunner implements AgentRunner {
+  readonly kind: "subprocess";
+  constructor(opts: SubprocessRunnerOpts);
+  start(scenario: Scenario): Effect.Effect<AgentHandle, AgentStartError, never>;
+  turn(h: AgentHandle, prompt: string, opts: { readonly timeoutMs: number }): Effect.Effect<Turn, AgentRunTimeoutError, never>;
+  diff(h: AgentHandle): Effect.Effect<WorkspaceDiff, never, never>;
+  stop(h: AgentHandle): Effect.Effect<void, never, never>;
+}


### PR DESCRIPTION
Architecture only. **Not for merge.**

Design doc: https://github.com/chughtapan/cc-judge/issues/4 (see comment after this PR is opened).

## Contents

16 TypeScript stub files under `src/`. Every function body is `throw new Error("not implemented")` or a `declare` stub. Every public signature has a named error channel via `Effect<T, E, R>` with a tagged error class (PRINCIPLES.md #3). Branded IDs, discriminated unions throughout (PRINCIPLES.md #1, #4). TypeBox chosen as the schema library at every data boundary (PRINCIPLES.md #2; resolves spec Q-ARCH-1).

## Modules (5)

- `src/core/` — types, tagged errors, TypeBox schemas, scenario loader
- `src/runner/` — `AgentRunner` + `DockerRunner` + `SubprocessRunner`
- `src/judge/` — `JudgeBackend` + `AnthropicJudgeBackend`
- `src/emit/` — `ReportEmitter` + `ObservabilityEmitter` + Braintrust/Promptfoo + OTel trace adapter
- `src/app/` — `runScenarios`, `runScenario`, `scoreTraces`, CLI

## Migration order for implement-staff

1. Commit 1 — `/safer:setup` on a fresh clone of `main` (the pointer-README commit gets replaced).
2. Commit 2 — tsconfig + eslint + package scaffold if `/safer:setup` split it.
3. Commit 3+ — fill in the stubs from this branch one module at a time (core first, runner+judge next, emit+app last).

## Cross-links

- Parent epic: chughtapan/cc-judge#1
- Spec (rev 2, plan-approved): chughtapan/cc-judge#3
- Architect sub-issue: chughtapan/cc-judge#4
- Research final report: chughtapan/cc-judge#2 (comment 4274475144)
