### PR TITLE
[impl-junior] fast-check property tests for scenario-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@typescript-eslint/parser": "8.19.0",
     "eslint": "9.17.0",
     "eslint-plugin-safer-by-default": "file:./tools/vendor/eslint-plugin-safer-by-default-0.0.3.tgz",
+    "fast-check": "4.7.0",
     "typescript": "5.6.3",
     "vitest": "2.1.9"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-plugin-safer-by-default:
         specifier: file:./tools/vendor/eslint-plugin-safer-by-default-0.0.3.tgz
         version: file:tools/vendor/eslint-plugin-safer-by-default-0.0.3.tgz(eslint@9.17.0)(typescript@5.6.3)
+      fast-check:
+        specifier: 4.7.0
+        version: 4.7.0
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -1197,6 +1200,10 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-check@4.7.0:
+    resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1476,6 +1483,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2824,6 +2834,10 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-check@4.7.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -3061,6 +3075,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  pure-rand@8.4.0: {}
 
   queue-microtask@1.2.3: {}
 

--- a/tests/scenario-loader.property.test.ts
+++ b/tests/scenario-loader.property.test.ts
@@ -1,0 +1,140 @@
+// Property-based tests for the scenario-loader boundary (Principle 2).
+// Four properties, mapped to cc-judge#8 acceptance.
+
+import { describe, it, expect } from "vitest";
+import { Effect } from "effect";
+import * as fc from "fast-check";
+import * as YAML from "yaml";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { scenarioLoader } from "../src/core/scenario.js";
+
+// Narrow ASCII arbitraries. We want YAML to round-trip identically, so we avoid
+// leading/trailing whitespace, YAML reserved start characters, and anything that
+// the stringifier might re-encode.
+const safeStringArb = fc.stringMatching(/^[A-Za-z][A-Za-z0-9 _.,?!:;-]{0,50}$/);
+const idArb = fc.stringMatching(/^[a-z][a-z0-9-]{0,40}$/);
+
+const segmentArb = fc.stringMatching(/^[a-z][a-z0-9_-]{0,15}$/);
+const cleanPathArb = fc
+  .array(segmentArb, { minLength: 1, maxLength: 4 })
+  .map((parts) => parts.join("/"));
+
+// A mix of clean and hostile paths. The schema's WORKSPACE_PATH_PATTERN must
+// reject every hostile shape; clean shapes may pass.
+const maybeDirtyPathArb = fc.oneof(
+  cleanPathArb,
+  cleanPathArb.map((p) => "/" + p),
+  cleanPathArb.map((p) => "../" + p),
+  cleanPathArb.map((p) => p + "/../etc"),
+  cleanPathArb.map((p) => "C:\\windows\\" + p.replaceAll("/", "\\")),
+  fc.stringMatching(/^[A-Za-z0-9./_-]{1,40}$/),
+);
+
+interface RawScenario {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly setupPrompt: string;
+  readonly expectedBehavior: string;
+  readonly validationChecks: ReadonlyArray<string>;
+  readonly workspace?: ReadonlyArray<{ readonly path: string; readonly content: string }>;
+}
+
+const validScenarioArb: fc.Arbitrary<RawScenario> = fc.record({
+  id: idArb,
+  name: safeStringArb,
+  description: safeStringArb,
+  setupPrompt: safeStringArb,
+  expectedBehavior: safeStringArb,
+  validationChecks: fc.array(safeStringArb, { minLength: 1, maxLength: 3 }),
+});
+
+describe("scenarioLoader properties", () => {
+  it("Prop1 roundtrip: YAML.stringify → loadFromYaml preserves the generated scenario", async () => {
+    await fc.assert(
+      fc.asyncProperty(validScenarioArb, async (raw) => {
+        const yamlStr = YAML.stringify(raw);
+        const decoded = await Effect.runPromise(
+          scenarioLoader.loadFromYaml(yamlStr, "mem://rt"),
+        );
+        expect(String(decoded.id)).toBe(raw.id);
+        expect(decoded.name).toBe(raw.name);
+        expect(decoded.description).toBe(raw.description);
+        expect(decoded.setupPrompt).toBe(raw.setupPrompt);
+        expect(decoded.expectedBehavior).toBe(raw.expectedBehavior);
+        expect([...decoded.validationChecks]).toEqual([...raw.validationChecks]);
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  it("Prop2 WORKSPACE_PATH_PATTERN invariant: any decoded workspace path is scenario-relative", async () => {
+    const base = {
+      id: "wp",
+      name: "wp",
+      description: "d",
+      setupPrompt: "p",
+      expectedBehavior: "e",
+      validationChecks: ["c"],
+    };
+    await fc.assert(
+      fc.asyncProperty(maybeDirtyPathArb, async (p) => {
+        const raw = { ...base, workspace: [{ path: p, content: "x" }] };
+        const yamlStr = YAML.stringify(raw);
+        const result = await Effect.runPromise(
+          Effect.either(scenarioLoader.loadFromYaml(yamlStr, "mem://wp")),
+        );
+        if (result._tag !== "Right") return;
+        for (const f of result.right.workspace ?? []) {
+          expect(f.path.startsWith("/")).toBe(false);
+          expect(f.path.includes("\\")).toBe(false);
+          expect(/^[A-Za-z]:/.test(f.path)).toBe(false);
+          expect(/(?:^|\/)\.\.(?:\/|$)/.test(f.path)).toBe(false);
+        }
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("Prop3 collision detection: two files with the same id yield a tagged DuplicateId error", async () => {
+    await fc.assert(
+      fc.asyncProperty(idArb, async (id) => {
+        const dir = mkdtempSync(path.join(os.tmpdir(), "ccj-prop-dup-"));
+        const body = `id: ${id}
+name: n
+description: d
+setupPrompt: p
+expectedBehavior: e
+validationChecks: [c]
+`;
+        writeFileSync(path.join(dir, "a.yaml"), body, "utf8");
+        writeFileSync(path.join(dir, "b.yaml"), body, "utf8");
+        const result = await Effect.runPromise(
+          Effect.either(scenarioLoader.loadFromPath(dir)),
+        );
+        expect(result._tag).toBe("Left");
+        if (result._tag === "Left") {
+          expect(result.left.cause._tag).toBe("DuplicateId");
+        }
+      }),
+      { numRuns: 20 },
+    );
+  });
+
+  it("Prop4 malformed input: arbitrary garbage resolves to a tagged LoadError, never an uncaught throw", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string(), async (garbage) => {
+        const result = await Effect.runPromise(
+          Effect.either(scenarioLoader.loadFromYaml(garbage, "mem://fuzz")),
+        );
+        if (result._tag === "Left") {
+          const t = result.left.cause._tag;
+          expect(t === "ParseFailure" || t === "SchemaInvalid").toBe(true);
+        }
+      }),
+      { numRuns: 200 },
+    );
+  });
+});


### PR DESCRIPTION
Closes #8

## What changed

Added `tests/scenario-loader.property.test.ts` with four fast-check properties against the scenario-loader boundary. Added `fast-check@4.7.0` as a devDependency. No loader-body changes.

## Scope
- Module: `src/core/scenario.ts` (tests only)
- Files touched: 3 (new test file + `package.json` + `pnpm-lock.yaml` for the one devDep)
- New exported signatures: none
- New runtime deps: none

## Properties

| # | Property | Runs | Status |
|---|---|---|---|
| 1 | Roundtrip — `YAML.stringify(raw) → loadFromYaml(...)` preserves fields on schema-valid scenario | 50 | PASS |
| 2 | `WORKSPACE_PATH_PATTERN` invariant — no decoded workspace path is absolute, drive-prefixed, contains `..`, or contains `\` | 200 | PASS |
| 3 | Collision — two files with identical ids yield a tagged `LoadError` with cause `DuplicateId` | 20 | PASS |
| 4 | Malformed — `fc.string()` garbage resolves to a tagged `LoadError` (`ParseFailure` \| `SchemaInvalid`), never an uncaught throw | 200 | PASS |

All four properties hold on the current impl.

## Tests
- 16 pre-existing tests still pass.
- 4 new property tests pass (`pnpm test` → 20/20).
- `pnpm typecheck && pnpm build && pnpm lint` green.

## Concerns (DONE_WITH_CONCERNS)

1. **Tag-name mismatch vs. #8 body.** The issue body names the collision error `ScenarioIdCollision`; the actual implementation uses `DuplicateId` (`src/core/errors.ts:16`). The property asserts the actual tag. The semantic invariant from the issue ("never silently last-wins") holds regardless. If the name should change, that is a rename in a separate PR — not in scope here.
2. **Test file location.** The architect plan used `src/core/scenario.ts` for the loader and `tests/` for tests. I put the new file in `tests/scenario-loader.property.test.ts` to match the project convention rather than the dispatch brief's suggested `src/core/scenario-loader.property.test.ts`. Vitest's `include` globs cover both.
3. **Roundtrip generator scope.** The valid-scenario arbitrary uses a narrow ASCII regex (`/^[A-Za-z][A-Za-z0-9 _.,?!:;-]{0,50}$/`) to avoid YAML.stringify re-quoting drift. It does not exercise optional fields (`followUps`, `workspace`, `timeoutMs`, `metadata`) or Unicode. A follow-up could widen the generator once a serializer is added; without one, roundtrip on exotic strings is really a YAML-library property, not a loader property.

## Confidence

HIGH — four properties, ~470 runs total, all pass locally on the current impl. Scope matches the junior budget: one module, tests + one dev dep, zero exported-signature changes, zero loader-body changes.