### PR TITLE
[impl-junior] build: chmod +x dist/bin.js after tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "pnpm clean && tsc",
+    "build": "pnpm clean && tsc && chmod +x dist/bin.js",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "lint": "eslint 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "vitest run",


### PR DESCRIPTION
Closes #17

## What changed
Append `&& chmod +x dist/bin.js` to the `build` script in `package.json`. `tsc` emits `dist/bin.js` with mode `0644`, so `./dist/bin.js` and `pnpm exec cc-judge` both fail on a fresh clone even though the shebang is present.

## Scope
- Module: `package.json` (build config only)
- New exported signatures: none
- New deps: none
- No source edits

## Verification
- `pnpm build` → `ls -l dist/bin.js` shows `-rwxrwxr-x`.
- `./dist/bin.js --help` prints yargs help on fresh clone.
- `pnpm test` → 23/23 passing.

## Confidence
HIGH — minimal one-line build-script chain; verified exec bit and CLI invocation on a fresh clone.