### PR TITLE
[impl-junior] Add --verbose to SubprocessRunner default args

### DIFF
--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -225,7 +225,7 @@ export interface SubprocessRunnerOpts {
   readonly extraArgs?: ReadonlyArray<string>;
 }
 
-const DEFAULT_CLAUDE_ARGS: ReadonlyArray<string> = ["-p", "--output-format", "stream-json"];
+const DEFAULT_CLAUDE_ARGS: ReadonlyArray<string> = ["-p", "--output-format", "stream-json", "--verbose"];
 
 export class SubprocessRunner implements AgentRunner {
   readonly kind: "subprocess" = "subprocess";

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { Effect } from "effect";
+import { SubprocessRunner } from "../src/runner/index.js";
+import { ScenarioId } from "../src/core/types.js";
+import type { Scenario } from "../src/core/schema.js";
+
+function makeScenario(): Scenario {
+  return {
+    id: ScenarioId("runner-verbose-flag"),
+    name: "runner-verbose-flag",
+    description: "test",
+    setupPrompt: "noop",
+    expectedBehavior: "noop",
+    validationChecks: [],
+  };
+}
+
+describe("SubprocessRunner default args", () => {
+  it("includes --verbose in the spawned command", async () => {
+    const runner = new SubprocessRunner({ bin: "/bin/echo" });
+    const scenario = makeScenario();
+    const handle = await Effect.runPromise(runner.start(scenario));
+    const turn = await Effect.runPromise(runner.turn(handle, "PROMPT-X", { timeoutMs: 10_000 }));
+    await Effect.runPromise(runner.stop(handle));
+    expect(turn.response).toContain("--verbose");
+    expect(turn.response).toContain("-p");
+    expect(turn.response).toContain("--output-format");
+    expect(turn.response).toContain("stream-json");
+    expect(turn.response).toContain("PROMPT-X");
+  });
+});


### PR DESCRIPTION
Closes #15

## What changed
`DEFAULT_CLAUDE_ARGS` at `src/runner/index.ts:228` now includes `--verbose`. Modern claude CLI (>= v2.1) rejects `-p --output-format stream-json` without it, so every SubprocessRunner run failed at startup. The constant is also reused by `DockerRunner` (line 468), so both runtimes are fixed by the single-line change.

## Scope
- Module: `src/runner/index.ts` (1-line change)
- Test: `tests/runner.test.ts` (new — 1 test)
- New exported signatures: none
- New deps: none

## Tests
- `SubprocessRunner default args > includes --verbose in the spawned command` — instantiates `SubprocessRunner` with `/bin/echo` as the bin and asserts the spawned argv contains `--verbose`, `-p`, `--output-format`, `stream-json`, and the prompt. No mocks.
- Full suite: 24 tests passing (was 23). Lint, typecheck, build green.

## Confidence
HIGH — single-line constant change; test exercises the real spawn path and asserts the argv directly.