### PR TITLE
[impl-staff] schema: required axis field on ScenarioYamlSchema

### DIFF
--- a/src/app/pipeline.ts
+++ b/src/app/pipeline.ts
@@ -330,10 +330,16 @@ export function scoreTraces(
 }
 
 function traceToScenario(trace: Trace): Scenario {
+  // Trace-scoring synthesizes a pseudo-Scenario so the judge interface can
+  // consume it. Traces don't carry an axis — the axis is a property of the
+  // authored scenario, not of a post-hoc trace. Default to artifact-discipline
+  // because trace scoring is "score a produced artifact," which is what that
+  // axis anchors.
   return {
     id: trace.scenarioId ?? scenarioIdFromTraceId(trace.traceId),
     name: trace.name,
     description: "",
+    axis: "artifact-discipline",
     setupPrompt: trace.turns.length > 0 ? (trace.turns[0]?.prompt ?? "") : "",
     expectedBehavior: trace.expectedBehavior,
     validationChecks: trace.validationChecks,

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -75,12 +75,34 @@ export const MetadataSchema = Type.Record(
   Type.Union([Type.String(), Type.Number(), Type.Boolean()]),
 );
 
+// Axis anchors a scenario to exactly one facet of the principle suite or a
+// cross-cutting doctrinal axis. Required so reports can aggregate pass-rate
+// by axis; the 11 values are spelled out as literals so the compiler rejects
+// typos at the scenario-author boundary (Principle 1: types beat tests). The
+// values are enumerated in safer-by-default docs/specs/evals-suite-v1.md §3.
+export const AxisSchema = Type.Union([
+  Type.Literal("principle-1-types-beat-tests"),
+  Type.Literal("principle-2-validate-at-boundaries"),
+  Type.Literal("principle-3-typed-errors"),
+  Type.Literal("principle-4-exhaustiveness"),
+  Type.Literal("principle-5-junior-dev-rule"),
+  Type.Literal("principle-6-budget-gate"),
+  Type.Literal("principle-7-brake"),
+  Type.Literal("principle-8-ratchet"),
+  Type.Literal("modality-routing"),
+  Type.Literal("artifact-discipline"),
+  Type.Literal("debt-multiplier"),
+]);
+
+export type Axis = Static<typeof AxisSchema>;
+
 // YAML-shaped Scenario. Function-valued deterministic checks cannot round-trip
 // through YAML; they are TS-only. ScenarioYamlSchema is the strict decode target.
 export const ScenarioYamlSchema = Type.Object({
   id: ScenarioIdSchema,
   name: Type.String({ minLength: 1 }),
   description: Type.String(),
+  axis: AxisSchema,
   setupPrompt: Type.String({ minLength: 1 }),
   followUps: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
   workspace: Type.Optional(Type.Array(WorkspaceFileSchema)),
@@ -98,6 +120,7 @@ export interface Scenario {
   readonly id: ScenarioId;
   readonly name: string;
   readonly description: string;
+  readonly axis: Axis;
   readonly setupPrompt: string;
   readonly followUps?: ReadonlyArray<string>;
   readonly workspace?: ReadonlyArray<WorkspaceFile>;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -11,6 +11,7 @@ function tmpScenarioDir(): string {
 id: cli-t
 name: cli-t
 description: d
+axis: principle-3-typed-errors
 setupPrompt: p
 expectedBehavior: e
 validationChecks: [c]

--- a/tests/integration/docker-runner.integration.test.ts
+++ b/tests/integration/docker-runner.integration.test.ts
@@ -22,6 +22,7 @@ const scenario: Scenario = {
   id: ScenarioId("it-docker-runner"),
   name: "integration",
   description: "",
+  axis: "principle-3-typed-errors",
   setupPrompt: "noop",
   expectedBehavior: "",
   validationChecks: ["noop"],

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -77,6 +77,7 @@ function makeScenario(id: string): Scenario {
     id: ScenarioId(id),
     name: id,
     description: "test",
+    axis: "principle-3-typed-errors",
     setupPrompt: "do it",
     expectedBehavior: "does it",
     validationChecks: ["does it"],

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -9,6 +9,7 @@ function makeScenario(): Scenario {
     id: ScenarioId("runner-verbose-flag"),
     name: "runner-verbose-flag",
     description: "test",
+    axis: "principle-3-typed-errors",
     setupPrompt: "noop",
     expectedBehavior: "noop",
     validationChecks: [],

--- a/tests/scenario-loader.property.test.ts
+++ b/tests/scenario-loader.property.test.ts
@@ -32,10 +32,27 @@ const maybeDirtyPathArb = fc.oneof(
   fc.stringMatching(/^[A-Za-z0-9./_-]{1,40}$/),
 );
 
+const AXES = [
+  "principle-1-types-beat-tests",
+  "principle-2-validate-at-boundaries",
+  "principle-3-typed-errors",
+  "principle-4-exhaustiveness",
+  "principle-5-junior-dev-rule",
+  "principle-6-budget-gate",
+  "principle-7-brake",
+  "principle-8-ratchet",
+  "modality-routing",
+  "artifact-discipline",
+  "debt-multiplier",
+] as const;
+type AxisLit = (typeof AXES)[number];
+const axisArb: fc.Arbitrary<AxisLit> = fc.constantFrom(...AXES);
+
 interface RawScenario {
   readonly id: string;
   readonly name: string;
   readonly description: string;
+  readonly axis: AxisLit;
   readonly setupPrompt: string;
   readonly expectedBehavior: string;
   readonly validationChecks: ReadonlyArray<string>;
@@ -46,6 +63,7 @@ const validScenarioArb: fc.Arbitrary<RawScenario> = fc.record({
   id: idArb,
   name: safeStringArb,
   description: safeStringArb,
+  axis: axisArb,
   setupPrompt: safeStringArb,
   expectedBehavior: safeStringArb,
   validationChecks: fc.array(safeStringArb, { minLength: 1, maxLength: 3 }),
@@ -62,6 +80,7 @@ describe("scenarioLoader properties", () => {
         expect(String(decoded.id)).toBe(raw.id);
         expect(decoded.name).toBe(raw.name);
         expect(decoded.description).toBe(raw.description);
+        expect(decoded.axis).toBe(raw.axis);
         expect(decoded.setupPrompt).toBe(raw.setupPrompt);
         expect(decoded.expectedBehavior).toBe(raw.expectedBehavior);
         expect([...decoded.validationChecks]).toEqual([...raw.validationChecks]);
@@ -75,6 +94,7 @@ describe("scenarioLoader properties", () => {
       id: "wp",
       name: "wp",
       description: "d",
+      axis: "principle-3-typed-errors",
       setupPrompt: "p",
       expectedBehavior: "e",
       validationChecks: ["c"],
@@ -105,6 +125,7 @@ describe("scenarioLoader properties", () => {
         const body = `id: ${id}
 name: n
 description: d
+axis: principle-3-typed-errors
 setupPrompt: p
 expectedBehavior: e
 validationChecks: [c]

--- a/tests/scenario-loader.test.ts
+++ b/tests/scenario-loader.test.ts
@@ -15,6 +15,7 @@ describe("scenarioLoader.loadFromYaml", () => {
 id: hello-world
 name: Hello World
 description: Agent prints hello world
+axis: principle-3-typed-errors
 setupPrompt: Say hello to the world
 expectedBehavior: The agent responds with a greeting
 validationChecks:
@@ -22,6 +23,7 @@ validationChecks:
 `;
     const scenario = await Effect.runPromise(scenarioLoader.loadFromYaml(yaml, "mem://hello"));
     expect(scenario.id).toBe("hello-world");
+    expect(scenario.axis).toBe("principle-3-typed-errors");
     expect(scenario.validationChecks).toEqual(["says hello"]);
   });
 
@@ -32,6 +34,81 @@ validationChecks:
     );
     expect(result._tag).toBe("Left");
   });
+
+  it("rejects YAML missing the required axis field", async () => {
+    const yaml = `
+id: no-axis
+name: NoAxis
+description: missing axis
+setupPrompt: do it
+expectedBehavior: done
+validationChecks: [done]
+`;
+    const result = await Effect.runPromise(
+      Effect.either(scenarioLoader.loadFromYaml(yaml, "mem://no-axis")),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left.cause._tag).toBe("SchemaInvalid");
+    }
+  });
+
+  it("rejects YAML whose axis value is not in the enumerated set", async () => {
+    const cases = [
+      "principle-9-nonexistent",
+      "principle-3",
+      "Principle-3-typed-errors",
+      "routing",
+      "",
+    ];
+    for (const badAxis of cases) {
+      const yaml = `
+id: bad-axis-${Buffer.from(badAxis).toString("hex").slice(0, 8) || "empty"}
+name: BadAxis
+description: invalid axis value
+axis: ${JSON.stringify(badAxis)}
+setupPrompt: do it
+expectedBehavior: done
+validationChecks: [done]
+`;
+      const result = await Effect.runPromise(
+        Effect.either(scenarioLoader.loadFromYaml(yaml, "mem://bad-axis")),
+      );
+      expect(result._tag, `expected Left for axis=${badAxis}`).toBe("Left");
+      if (result._tag === "Left") {
+        expect(result.left.cause._tag).toBe("SchemaInvalid");
+      }
+    }
+  });
+
+  it("accepts every enumerated axis literal", async () => {
+    const axes = [
+      "principle-1-types-beat-tests",
+      "principle-2-validate-at-boundaries",
+      "principle-3-typed-errors",
+      "principle-4-exhaustiveness",
+      "principle-5-junior-dev-rule",
+      "principle-6-budget-gate",
+      "principle-7-brake",
+      "principle-8-ratchet",
+      "modality-routing",
+      "artifact-discipline",
+      "debt-multiplier",
+    ];
+    for (const axis of axes) {
+      const yaml = `
+id: ok-${axis}
+name: OK
+description: valid axis
+axis: ${axis}
+setupPrompt: do it
+expectedBehavior: done
+validationChecks: [done]
+`;
+      const scenario = await Effect.runPromise(scenarioLoader.loadFromYaml(yaml, "mem://ok"));
+      expect(scenario.axis).toBe(axis);
+    }
+  });
 });
 
 describe("scenarioLoader.loadFromPath", () => {
@@ -41,6 +118,7 @@ describe("scenarioLoader.loadFromPath", () => {
 id: scen-a
 name: A
 description: first
+axis: principle-1-types-beat-tests
 setupPrompt: do A
 expectedBehavior: produces A
 validationChecks:
@@ -50,6 +128,7 @@ validationChecks:
 id: scen-b
 name: B
 description: second
+axis: modality-routing
 setupPrompt: do B
 expectedBehavior: produces B
 validationChecks:
@@ -67,6 +146,7 @@ validationChecks:
 id: dup
 name: Dup
 description: d
+axis: debt-multiplier
 setupPrompt: p
 expectedBehavior: e
 validationChecks: [c]
@@ -90,6 +170,7 @@ validationChecks: [c]
 id: wp-${Buffer.from(badPath).toString("hex").slice(0, 8)}
 name: wp
 description: d
+axis: artifact-discipline
 setupPrompt: p
 expectedBehavior: e
 validationChecks: [c]


### PR DESCRIPTION
Spec: chughtapan/safer-by-default#70 — `docs/specs/evals-suite-v1.md` §3
Parent (multi-repo): first of two staff PRs. PR 2 (safer-by-default) scaffolds `scenarios/` + first 4 scenarios and must land **after** this one.

## What changed

Extends `ScenarioYamlSchema` with a required `axis` field, enumerated as 11 `Type.Literal` values. Adds `AxisSchema` + exported `Axis` type alias. Mirrors the change on the hand-written `Scenario` interface. Updates every existing test fixture to carry an explicit axis. Trace-scoring synthesizes a pseudo-Scenario; defaults `axis: "artifact-discipline"` with a comment explaining why (trace scoring is "score a produced artifact").

Adds two new tests:
- `rejects YAML missing the required axis field` (SchemaInvalid)
- `rejects YAML whose axis value is not in the enumerated set` (5 typo/casing/bad-string cases)
- `accepts every enumerated axis literal` (11 positives — belt-and-braces against accidental literal rename)

No back-compat shim. The field is required at the decode boundary. Rationale anchored to spec §3 and Principle 1: a typo at the scenario-author boundary should be a decode error, not an unset field that silently misroutes aggregation.

## Traceability

| New artifact | Kind | Spec anchor |
|---|---|---|
| `AxisSchema` (11 literals) | new exported const | §3 schema proposal |
| `Axis` type alias | new exported type | §3 schema proposal |
| `axis` field on `ScenarioYamlSchema` | new required field | §3 schema proposal |
| `axis` field on `Scenario` interface | new required field | §3 schema proposal |
| `traceToScenario` default axis | minimal internal change | §7 "this spec only commits to the new field on scenario inputs" (trace synthesis is not a scenario input) |

## Scope

- Modules changed: `src/core/schema.ts`, `src/app/pipeline.ts` (one-line default for synthesized pseudo-Scenario)
- New public exports: `AxisSchema`, `Axis`
- New deps: none
- Tests: 9 loader tests (up from 7), all other suites unchanged in intent, updated fixtures only
- Tier (expected): staff

## Tests

- `tests/scenario-loader.test.ts` — axis decode, axis rejection, enumerated-value acceptance.
- `tests/scenario-loader.property.test.ts` — axis added to the valid-scenario arbitrary; Prop1 asserts axis round-trips.
- `tests/runner.test.ts`, `tests/pipeline.test.ts`, `tests/cli.test.ts`, `tests/integration/docker-runner.integration.test.ts` — existing fixtures carry axis.

All local: `pnpm lint`, `pnpm typecheck`, `pnpm test` pass (27 tests across 8 files).

## Notes for reviewer

- The existing dogfood PR #14 (draft, unmerged) contains `scenarios/acg-rule-coverage/no-raw-throw-to-tagged.yaml` without an `axis` field. If #14 merges ahead of this PR, rebase will require adding `axis: principle-3-typed-errors` to that file. PR 2 on safer-by-default will migrate this scenario into the new `scenarios/` tree (with axis) regardless.
- No report-layer aggregation work here (explicitly out of scope per spec §3 "Aggregation hook ... out of scope here").

## Confidence

HIGH — schema extension is a narrow change; every test fixture updated; all tests pass locally.

Related: chughtapan/safer-by-default#70