### PR TITLE
[impl-staff] add multi-agent coordinator and bundle path

### DIFF
--- a/src/app/opts.ts
+++ b/src/app/opts.ts
@@ -3,8 +3,8 @@
 
 import type { JudgeBackend } from "../judge/index.js";
 import type { ObservabilityEmitter } from "../emit/observability.js";
-import type { AgentRunner } from "../runner/index.js";
-import type { LogLevel } from "../core/types.js";
+import type { AgentRunner, AgentRuntime, ExecutionHarness, RunCoordinator } from "../runner/index.js";
+import type { LogLevel, RunPlan } from "../core/types.js";
 import type { TraceFormat } from "../emit/trace-adapter.js";
 
 export interface SharedOpts {
@@ -22,9 +22,21 @@ export interface SharedOpts {
 
 export interface RunOpts extends SharedOpts {
   readonly runner?: AgentRunner;
+  readonly runtime?: AgentRuntime;
+  readonly coordinator?: RunCoordinator;
   readonly scenarioIdFilter?: ReadonlyArray<string>;
 }
 
 export interface ScoreOpts extends SharedOpts {
   readonly traceFormat?: TraceFormat;
+}
+
+export interface HarnessRunOpts extends SharedOpts {
+  readonly runtime?: AgentRuntime;
+  readonly coordinator?: RunCoordinator;
+}
+
+export interface PlannedRunInput {
+  readonly plan: RunPlan;
+  readonly harness: ExecutionHarness;
 }

--- a/src/app/pipeline.ts
+++ b/src/app/pipeline.ts
@@ -3,6 +3,7 @@
 // failures fold into per-run RunRecords; the pipeline always produces a Report.
 
 import { Effect } from "effect";
+import { randomUUID } from "node:crypto";
 import type { Report, RunRecord, Scenario, Trace, JudgeResult } from "../core/schema.js";
 import type {
   JudgmentBundle,
@@ -624,7 +625,7 @@ function coordinationFailureBundle(
   outcomes: ReadonlyArray<JudgmentBundle["outcomes"][number]>,
 ): JudgmentBundle {
   return {
-    runId: RunId(`${plan.project}:${plan.scenarioId}:failed:${Date.now()}`),
+    runId: RunId(randomUUID()),
     project: plan.project,
     scenarioId: plan.scenarioId,
     name: plan.name,

--- a/src/app/pipeline.ts
+++ b/src/app/pipeline.ts
@@ -33,7 +33,13 @@ import {
 } from "../runner/index.js";
 import { makeReportEmitter, type ReportEmitter } from "../emit/report.js";
 import type { ObservabilityEmitter } from "../emit/observability.js";
-import { RunnerResolutionError } from "../core/errors.js";
+import {
+  RunCoordinationError,
+  RunnerResolutionError,
+  type AgentStartErrorCause,
+  type BundleBuildCause,
+  type HarnessExecutionCause,
+} from "../core/errors.js";
 import type { HarnessRunOpts, PlannedRunInput, RunOpts, ScoreOpts } from "./opts.js";
 
 const DEFAULT_RUNS_PER_SCENARIO = 1;
@@ -429,17 +435,18 @@ function runOnePlannedInput(
     const startMs = Date.now();
     const executionOpts = abortSignal !== undefined ? { abortSignal } : {};
     const execution = yield* Effect.either(coordinator.execute(input.plan, input.harness, executionOpts));
-    const bundle = execution._tag === "Right"
-      ? execution.right
-      : coordinationFailureBundle(input.plan, execution.left);
-    const judgeResult = yield* judgeBundle(judge, bundle, abortSignal);
-    const record = buildBundleRecord({
-      bundle,
-      judge: judgeResult,
-      judgeModel: judge.name,
-      startedAt,
-      latencyMs: Date.now() - startMs,
-    });
+    const latencyMs = Date.now() - startMs;
+    const record = execution._tag === "Right"
+      ? buildBundleRecord({
+          bundle: execution.right,
+          judge: yield* judgeBundle(judge, execution.right, abortSignal),
+          judgeModel: judge.name,
+          startedAt,
+          latencyMs,
+        })
+      : buildBundleRecord(
+          coordinationFailureRecordInput(input.plan, execution.left, startedAt, latencyMs, abortSignal),
+        );
     yield* emitter.emitRun(record);
     yield* Effect.forEach(obs, (observer) => observer.onRun({ record }), { discard: true });
     return record;
@@ -586,7 +593,36 @@ function scoreOneBundle(
   });
 }
 
-function coordinationFailureBundle(plan: RunPlan, error: { readonly cause: { readonly _tag: string } }): JudgmentBundle {
+function coordinationFailureRecordInput(
+  plan: RunPlan,
+  error: RunCoordinationError,
+  startedAt: string,
+  latencyMs: number,
+  abortSignal: AbortSignal | undefined,
+): {
+  readonly bundle: JudgmentBundle;
+  readonly judge: JudgeResult;
+  readonly judgeModel: string;
+  readonly startedAt: string;
+  readonly latencyMs: number;
+} {
+  const endedAt = nowIso();
+  const outcomes = coordinationFailureOutcomes(plan, error, endedAt, abortSignal);
+  const judge = deterministicFailureJudge(outcomes);
+  return {
+    bundle: coordinationFailureBundle(plan, error, outcomes),
+    judge,
+    judgeModel: "deterministic/coordinator",
+    startedAt,
+    latencyMs,
+  };
+}
+
+function coordinationFailureBundle(
+  plan: RunPlan,
+  error: RunCoordinationError,
+  outcomes: ReadonlyArray<JudgmentBundle["outcomes"][number]>,
+): JudgmentBundle {
   return {
     runId: RunId(`${plan.project}:${plan.scenarioId}:failed:${Date.now()}`),
     project: plan.project,
@@ -595,15 +631,117 @@ function coordinationFailureBundle(plan: RunPlan, error: { readonly cause: { rea
     description: plan.description,
     requirements: plan.requirements,
     agents: plan.agents.map(agentRefFromDeclaration),
-    outcomes: plan.agents.map((agent) => ({
-      agentId: agent.id,
-      status: "runtime_error" as const,
-      endedAt: nowIso(),
-      reason: `coordination failed: ${error.cause._tag}`,
-    })),
+    outcomes: [...outcomes],
     metadata: {
       coordinationFailure: error.cause._tag,
       modelName: `${plan.project}/coordinator`,
+      failureFold: "deterministic",
     },
   };
+}
+
+function coordinationFailureOutcomes(
+  plan: RunPlan,
+  error: RunCoordinationError,
+  endedAt: string,
+  abortSignal: AbortSignal | undefined,
+): ReadonlyArray<JudgmentBundle["outcomes"][number]> {
+  const cancelledReason = abortSignal?.aborted === true
+    ? "run cancelled via abort signal"
+    : "run cancelled after another agent failed";
+  const cause = error.cause;
+  switch (cause._tag) {
+    case "AgentStartFailed":
+      return plan.agents.map((agent) =>
+        agent.id === cause.agentId
+          ? {
+              agentId: agent.id,
+              status: "failed_to_start" as const,
+              endedAt,
+              reason: renderAgentStartCause(cause.detail),
+            }
+          : {
+              agentId: agent.id,
+              status: "cancelled" as const,
+              endedAt,
+              reason: cancelledReason,
+            });
+    case "HarnessFailed":
+      return plan.agents.map((agent) => ({
+        agentId: agent.id,
+        status: abortSignal?.aborted === true ? "cancelled" as const : "runtime_error" as const,
+        endedAt,
+        reason: abortSignal?.aborted === true ? cancelledReason : renderHarnessFailureCause(cause.detail),
+      }));
+    case "BundleBuildFailed":
+      return plan.agents.map((agent) => ({
+        agentId: agent.id,
+        status: abortSignal?.aborted === true ? "cancelled" as const : "runtime_error" as const,
+        endedAt,
+        reason: abortSignal?.aborted === true ? cancelledReason : renderBundleBuildFailureCause(cause.detail),
+      }));
+  }
+}
+
+function deterministicFailureJudge(
+  outcomes: ReadonlyArray<JudgmentBundle["outcomes"][number]>,
+): JudgeResult {
+  const issues = outcomes.map((outcome) => ({
+    issue: `${outcome.agentId} ${outcome.status}${outcome.reason !== undefined ? `: ${outcome.reason}` : ""}`,
+    severity: "critical" as const,
+  }));
+  return {
+    pass: false,
+    reason: `coordination failed: ${issues.map((issue) => issue.issue).join("; ")}`,
+    issues,
+    overallSeverity: "critical",
+    retryCount: 0,
+  };
+}
+
+function renderAgentStartCause(cause: AgentStartErrorCause): string {
+  switch (cause._tag) {
+    case "BuildContextMissing":
+      return `build context missing at ${cause.path}`;
+    case "DockerBuildFailed":
+      return `docker build failed: ${cause.message}`;
+    case "ImageMissing":
+      return `image missing: ${cause.image}`;
+    case "ImagePullFailed":
+      return `image pull failed for ${cause.image}: ${cause.message}`;
+    case "ContainerStartFailed":
+      return `container start failed: ${cause.message}`;
+    case "BinaryNotFound":
+      return `binary not found: ${cause.path}`;
+    case "WorkspacePathEscape":
+      return `workspace path escaped root: ${cause.wfPath}`;
+    case "WorkspaceSetupFailed":
+      return `workspace setup failed: ${cause.message}`;
+  }
+}
+
+function renderHarnessFailureCause(cause: HarnessExecutionCause): string {
+  switch (cause._tag) {
+    case "MissingRuntimeHandle":
+      return `missing runtime handle for ${cause.agentId}`;
+    case "InvalidPlanMetadata":
+      return cause.message;
+    case "ExecutionFailed":
+      return cause.message;
+  }
+}
+
+function renderBundleBuildFailureCause(cause: BundleBuildCause): string {
+  switch (cause._tag) {
+    case "DuplicateOutcome":
+      return `duplicate outcome emitted for ${cause.agentId}`;
+    case "MissingOutcomes":
+      return `missing outcomes for ${cause.agentIds.join(", ")}`;
+    case "UnknownAgent":
+      return `unknown agent ${cause.agentId}`;
+    case "EventOrderViolation":
+      return `event order violated: ${String(cause.previousTs)} before ${String(cause.nextTs)}`;
+    case "SchemaInvalid":
+      return `bundle schema invalid: ${cause.errors.join("; ")}`;
+  }
 }

--- a/src/app/pipeline.ts
+++ b/src/app/pipeline.ts
@@ -5,6 +5,9 @@
 import { Effect } from "effect";
 import type { Report, RunRecord, Scenario, Trace, JudgeResult } from "../core/schema.js";
 import type {
+  JudgmentBundle,
+  RunPlan,
+  AgentTurn,
   Turn,
   WorkspaceDiff,
   IssueSeverity,
@@ -12,13 +15,26 @@ import type {
   RunNumber as RunNumberType,
   TraceId as TraceIdType,
 } from "../core/types.js";
-import { RunNumber, scenarioIdFromTraceId } from "../core/types.js";
-import { AnthropicJudgeBackend, type JudgeBackend } from "../judge/index.js";
-import { DockerRunner, SubprocessRunner, type AgentRunner, type AgentHandle } from "../runner/index.js";
+import {
+  RUN_SOURCE,
+  RunId,
+  RunNumber,
+  agentRefFromDeclaration,
+  scenarioIdFromTraceId,
+} from "../core/types.js";
+import { AnthropicJudgeBackend, judgeBundle, type JudgeBackend } from "../judge/index.js";
+import {
+  DefaultRunCoordinator,
+  DockerRuntime,
+  DockerRunner,
+  SubprocessRunner,
+  type AgentRunner,
+  type AgentHandle,
+} from "../runner/index.js";
 import { makeReportEmitter, type ReportEmitter } from "../emit/report.js";
 import type { ObservabilityEmitter } from "../emit/observability.js";
 import { RunnerResolutionError } from "../core/errors.js";
-import type { RunOpts, ScoreOpts } from "./opts.js";
+import type { HarnessRunOpts, PlannedRunInput, RunOpts, ScoreOpts } from "./opts.js";
 
 const DEFAULT_RUNS_PER_SCENARIO = 1;
 const DEFAULT_CONCURRENCY = 1;
@@ -114,6 +130,65 @@ function buildRecord(params: {
     workspaceDiffSummary: summary,
   };
   return params.traceId !== undefined ? { ...base, traceId: params.traceId } : base;
+}
+
+function sumAgentTurns(turns: ReadonlyArray<AgentTurn> | undefined): {
+  readonly toolCallCount: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+} {
+  if (turns === undefined) {
+    return {
+      toolCallCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+  }
+  return sumTurns(turns.map((entry) => entry.turn));
+}
+
+function bundleModelName(bundle: JudgmentBundle): string {
+  const modelName = bundle.metadata?.["modelName"];
+  return typeof modelName === "string" && modelName.length > 0
+    ? modelName
+    : `${bundle.project}/bundle`;
+}
+
+function buildBundleRecord(params: {
+  readonly bundle: JudgmentBundle;
+  readonly judge: JudgeResult;
+  readonly judgeModel: string;
+  readonly startedAt: string;
+  readonly latencyMs: number;
+}): RunRecord {
+  const agg = sumAgentTurns(params.bundle.turns);
+  const summary = summarizeDiff(params.bundle.workspaceDiff);
+  return {
+    source: RUN_SOURCE.Bundle,
+    scenarioId: params.bundle.scenarioId,
+    runNumber: RunNumber(1),
+    modelName: bundleModelName(params.bundle),
+    judgeModel: params.judgeModel,
+    startedAt: params.startedAt,
+    latencyMs: params.latencyMs,
+    pass: params.judge.pass,
+    reason: params.judge.reason,
+    issues: params.judge.issues,
+    overallSeverity: params.judge.overallSeverity as IssueSeverity | null,
+    judgeConfidence: params.judge.judgeConfidence ?? null,
+    retryCount: params.judge.retryCount,
+    toolCallCount: agg.toolCallCount,
+    inputTokens: agg.inputTokens,
+    outputTokens: agg.outputTokens,
+    cacheReadTokens: agg.cacheReadTokens,
+    cacheWriteTokens: agg.cacheWriteTokens,
+    transcriptPath: "",
+    workspaceDiffSummary: summary,
+  };
 }
 
 function runAgentTurns(
@@ -297,6 +372,111 @@ export function runScenario(scenario: Scenario, opts: RunOpts = {}): Effect.Effe
   return runScenarios([scenario], opts);
 }
 
+function resolveCoordinator(opts: HarnessRunOpts) {
+  return opts.coordinator ?? new DefaultRunCoordinator(opts.runtime ?? new DockerRuntime());
+}
+
+export function runWithHarness(
+  plan: RunPlan,
+  harness: PlannedRunInput["harness"],
+  opts: HarnessRunOpts = {},
+): Effect.Effect<Report, never, never> {
+  return runPlans([{ plan, harness }], opts);
+}
+
+export function runPlans(
+  inputs: ReadonlyArray<PlannedRunInput>,
+  opts: HarnessRunOpts = {},
+): Effect.Effect<Report, never, never> {
+  return Effect.gen(function* () {
+    const judge = opts.judge ?? new AnthropicJudgeBackend();
+    const resultsDir = opts.resultsDir ?? "./eval-results";
+    const emitter = makeReportEmitter({
+      resultsDir,
+      ...(opts.githubComment !== undefined ? { githubComment: opts.githubComment } : {}),
+      ...(opts.githubCommentArtifactUrl !== undefined
+        ? { githubCommentArtifactUrl: opts.githubCommentArtifactUrl }
+        : {}),
+    });
+    const obs = opts.emitters ?? [];
+    const concurrency = Math.max(1, opts.concurrency ?? DEFAULT_CONCURRENCY);
+    const coordinator = resolveCoordinator(opts);
+    const records = yield* Effect.forEach(
+      inputs,
+      (input) => runOnePlannedInput(input, coordinator, judge, emitter, obs, opts.abortSignal),
+      { concurrency },
+    );
+    const report = buildReport(records, resultsDir);
+    yield* emitter.emitReport(report);
+    yield* Effect.forEach(obs, (observer) => observer.onReport({ report }), { discard: true });
+    if (opts.githubComment !== undefined) {
+      yield* emitter.publishGithubComment(report).pipe(Effect.catchAll(() => Effect.void));
+    }
+    return report;
+  });
+}
+
+function runOnePlannedInput(
+  input: PlannedRunInput,
+  coordinator: ReturnType<typeof resolveCoordinator>,
+  judge: JudgeBackend,
+  emitter: ReportEmitter,
+  obs: ReadonlyArray<ObservabilityEmitter>,
+  abortSignal: AbortSignal | undefined,
+): Effect.Effect<RunRecord, never, never> {
+  return Effect.gen(function* () {
+    const startedAt = nowIso();
+    const startMs = Date.now();
+    const executionOpts = abortSignal !== undefined ? { abortSignal } : {};
+    const execution = yield* Effect.either(coordinator.execute(input.plan, input.harness, executionOpts));
+    const bundle = execution._tag === "Right"
+      ? execution.right
+      : coordinationFailureBundle(input.plan, execution.left);
+    const judgeResult = yield* judgeBundle(judge, bundle, abortSignal);
+    const record = buildBundleRecord({
+      bundle,
+      judge: judgeResult,
+      judgeModel: judge.name,
+      startedAt,
+      latencyMs: Date.now() - startMs,
+    });
+    yield* emitter.emitRun(record);
+    yield* Effect.forEach(obs, (observer) => observer.onRun({ record }), { discard: true });
+    return record;
+  });
+}
+
+export function scoreBundles(
+  bundles: ReadonlyArray<JudgmentBundle>,
+  opts: ScoreOpts = {},
+): Effect.Effect<Report, never, never> {
+  return Effect.gen(function* () {
+    const judge = opts.judge ?? new AnthropicJudgeBackend();
+    const resultsDir = opts.resultsDir ?? "./eval-results";
+    const emitter = makeReportEmitter({
+      resultsDir,
+      ...(opts.githubComment !== undefined ? { githubComment: opts.githubComment } : {}),
+      ...(opts.githubCommentArtifactUrl !== undefined
+        ? { githubCommentArtifactUrl: opts.githubCommentArtifactUrl }
+        : {}),
+    });
+    const obs = opts.emitters ?? [];
+    const concurrency = Math.max(1, opts.concurrency ?? DEFAULT_CONCURRENCY);
+    const records = yield* Effect.forEach(
+      bundles,
+      (bundle) => scoreOneBundle(bundle, judge, emitter, obs, opts.abortSignal),
+      { concurrency },
+    );
+    const report = buildReport(records, resultsDir);
+    yield* emitter.emitReport(report);
+    yield* Effect.forEach(obs, (observer) => observer.onReport({ report }), { discard: true });
+    if (opts.githubComment !== undefined) {
+      yield* emitter.publishGithubComment(report).pipe(Effect.catchAll(() => Effect.void));
+    }
+    return report;
+  });
+}
+
 export function scoreTraces(
   traces: ReadonlyArray<Trace>,
   opts: ScoreOpts = {},
@@ -321,7 +501,7 @@ export function scoreTraces(
     );
     const report = buildReport(records, resultsDir);
     yield* emitter.emitReport(report);
-    yield* Effect.forEach(obs, (e) => e.onReport({ report }), { discard: true });
+    yield* Effect.forEach(obs, (observer) => observer.onReport({ report }), { discard: true });
     if (opts.githubComment !== undefined) {
       yield* emitter.publishGithubComment(report).pipe(Effect.catchAll(() => Effect.void));
     }
@@ -377,7 +557,53 @@ function scoreOneTrace(
       traceId: trace.traceId,
     });
     yield* emitter.emitRun(record);
+    yield* Effect.forEach(obs, (observer) => observer.onRun({ record }), { discard: true });
+    return record;
+  });
+}
+
+function scoreOneBundle(
+  bundle: JudgmentBundle,
+  judge: JudgeBackend,
+  emitter: ReportEmitter,
+  obs: ReadonlyArray<ObservabilityEmitter>,
+  abortSignal: AbortSignal | undefined,
+): Effect.Effect<RunRecord, never, never> {
+  return Effect.gen(function* () {
+    const startedAt = nowIso();
+    const startMs = Date.now();
+    const judgeResult = yield* judgeBundle(judge, bundle, abortSignal);
+    const record = buildBundleRecord({
+      bundle,
+      judge: judgeResult,
+      judgeModel: judge.name,
+      startedAt,
+      latencyMs: Date.now() - startMs,
+    });
+    yield* emitter.emitRun(record);
     yield* Effect.forEach(obs, (e) => e.onRun({ record }), { discard: true });
     return record;
   });
+}
+
+function coordinationFailureBundle(plan: RunPlan, error: { readonly cause: { readonly _tag: string } }): JudgmentBundle {
+  return {
+    runId: RunId(`${plan.project}:${plan.scenarioId}:failed:${Date.now()}`),
+    project: plan.project,
+    scenarioId: plan.scenarioId,
+    name: plan.name,
+    description: plan.description,
+    requirements: plan.requirements,
+    agents: plan.agents.map(agentRefFromDeclaration),
+    outcomes: plan.agents.map((agent) => ({
+      agentId: agent.id,
+      status: "runtime_error" as const,
+      endedAt: nowIso(),
+      reason: `coordination failed: ${error.cause._tag}`,
+    })),
+    metadata: {
+      coordinationFailure: error.cause._tag,
+      modelName: `${plan.project}/coordinator`,
+    },
+  };
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -2,7 +2,7 @@
 // Principle 3: errors are typed, not thrown. Every cause is a discriminated tag.
 
 import { Data } from "effect";
-import type { ScenarioId } from "./types.js";
+import type { AgentId, ScenarioId } from "./types.js";
 
 export class LoadError extends Data.TaggedError("LoadError")<{
   readonly cause: LoadErrorCause;
@@ -17,11 +17,15 @@ export type LoadErrorCause =
 
 export class AgentStartError extends Data.TaggedError("AgentStartError")<{
   readonly scenarioId: ScenarioId;
+  readonly agentId?: AgentId;
   readonly cause: AgentStartErrorCause;
 }> {}
 
 export type AgentStartErrorCause =
+  | { readonly _tag: "BuildContextMissing"; readonly path: string }
+  | { readonly _tag: "DockerBuildFailed"; readonly message: string }
   | { readonly _tag: "ImageMissing"; readonly image: string }
+  | { readonly _tag: "ImagePullFailed"; readonly image: string; readonly message: string }
   | { readonly _tag: "ContainerStartFailed"; readonly message: string }
   | { readonly _tag: "BinaryNotFound"; readonly path: string }
   | { readonly _tag: "WorkspacePathEscape"; readonly wfPath: string }
@@ -45,6 +49,43 @@ export class TraceDecodeError extends Data.TaggedError("TraceDecodeError")<{
 export type TraceDecodeCause =
   | { readonly _tag: "UnknownFormat"; readonly path: string }
   | { readonly _tag: "SchemaInvalid"; readonly path: string; readonly errors: ReadonlyArray<string> };
+
+export class BundleDecodeError extends Data.TaggedError("BundleDecodeError")<{
+  readonly cause: BundleDecodeCause;
+}> {}
+
+export type BundleDecodeCause =
+  | { readonly _tag: "UnknownFormat"; readonly path: string }
+  | { readonly _tag: "SchemaInvalid"; readonly path: string; readonly errors: ReadonlyArray<string> };
+
+export class BundleBuildError extends Data.TaggedError("BundleBuildError")<{
+  readonly cause: BundleBuildCause;
+}> {}
+
+export type BundleBuildCause =
+  | { readonly _tag: "DuplicateOutcome"; readonly agentId: string }
+  | { readonly _tag: "MissingOutcomes"; readonly agentIds: ReadonlyArray<string> }
+  | { readonly _tag: "UnknownAgent"; readonly agentId: string }
+  | { readonly _tag: "EventOrderViolation"; readonly previousTs: number; readonly nextTs: number }
+  | { readonly _tag: "SchemaInvalid"; readonly errors: ReadonlyArray<string> };
+
+export class HarnessExecutionError extends Data.TaggedError("HarnessExecutionError")<{
+  readonly cause: HarnessExecutionCause;
+}> {}
+
+export type HarnessExecutionCause =
+  | { readonly _tag: "MissingRuntimeHandle"; readonly agentId: string }
+  | { readonly _tag: "InvalidPlanMetadata"; readonly message: string }
+  | { readonly _tag: "ExecutionFailed"; readonly message: string };
+
+export class RunCoordinationError extends Data.TaggedError("RunCoordinationError")<{
+  readonly cause: RunCoordinationCause;
+}> {}
+
+export type RunCoordinationCause =
+  | { readonly _tag: "AgentStartFailed"; readonly agentId: string; readonly detail: AgentStartErrorCause }
+  | { readonly _tag: "HarnessFailed"; readonly detail: HarnessExecutionCause }
+  | { readonly _tag: "BundleBuildFailed"; readonly detail: BundleBuildCause };
 
 export class PublishError extends Data.TaggedError("PublishError")<{
   readonly cause: PublishErrorCause;
@@ -81,7 +122,10 @@ export const LOAD_ERROR_CAUSE = {
 } as const satisfies { readonly [K in LoadErrorCause["_tag"]]: K };
 
 export const AGENT_START_CAUSE = {
+  BuildContextMissing: "BuildContextMissing",
+  DockerBuildFailed: "DockerBuildFailed",
   ImageMissing: "ImageMissing",
+  ImagePullFailed: "ImagePullFailed",
   ContainerStartFailed: "ContainerStartFailed",
   BinaryNotFound: "BinaryNotFound",
   WorkspacePathEscape: "WorkspacePathEscape",

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -18,6 +18,9 @@ import type {
   WorkspaceFile,
 } from "./types.js";
 
+export const ProjectIdSchema = Type.String({ minLength: 1, maxLength: 256 });
+export const RunIdSchema = Type.String({ minLength: 1, maxLength: 256 });
+export const AgentIdSchema = Type.String({ minLength: 1, maxLength: 256 });
 export const ScenarioIdSchema = Type.String({ minLength: 1, maxLength: 256 });
 export const TraceIdSchema = Type.String({ minLength: 1, maxLength: 256 });
 
@@ -28,6 +31,7 @@ export const IssueSeveritySchema = Type.Union([
 ]);
 
 export const RunSourceSchema = Type.Union([
+  Type.Literal("bundle"),
   Type.Literal("scenario"),
   Type.Literal("trace"),
 ]);
@@ -78,6 +82,55 @@ export const MetadataSchema = Type.Record(
   Type.Union([Type.String(), Type.Number(), Type.Boolean()]),
 );
 
+export const UnknownRecordSchema = Type.Record(Type.String(), Type.Unknown());
+
+export const ExecutionArtifactSchema = Type.Union([
+  Type.Object({
+    _tag: Type.Literal("DockerBuildArtifact"),
+    contextPath: Type.String({ minLength: 1 }),
+    dockerfilePath: Type.Optional(Type.String({ minLength: 1 })),
+    target: Type.Optional(Type.String({ minLength: 1 })),
+    buildArgs: Type.Optional(Type.Record(Type.String(), Type.String())),
+    imageTag: Type.Optional(Type.String({ minLength: 1 })),
+  }),
+  Type.Object({
+    _tag: Type.Literal("DockerImageArtifact"),
+    image: Type.String({ minLength: 1 }),
+    pullPolicy: Type.Optional(
+      Type.Union([
+        Type.Literal("always"),
+        Type.Literal("if-missing"),
+        Type.Literal("never"),
+      ]),
+    ),
+  }),
+]);
+
+export const AgentDeclarationSchema = Type.Object({
+  id: AgentIdSchema,
+  name: Type.String({ minLength: 1 }),
+  role: Type.Optional(Type.String({ minLength: 1 })),
+  artifact: ExecutionArtifactSchema,
+  promptInputs: UnknownRecordSchema,
+  metadata: Type.Optional(UnknownRecordSchema),
+});
+
+export const RunRequirementsSchema = Type.Object({
+  expectedBehavior: Type.String(),
+  validationChecks: Type.Array(Type.String({ minLength: 1 })),
+  judgeRubric: Type.Optional(Type.String()),
+});
+
+export const RunPlanSchema = Type.Object({
+  project: ProjectIdSchema,
+  scenarioId: ScenarioIdSchema,
+  name: Type.String({ minLength: 1 }),
+  description: Type.String(),
+  agents: Type.Array(AgentDeclarationSchema, { minItems: 1 }),
+  requirements: RunRequirementsSchema,
+  metadata: Type.Optional(UnknownRecordSchema),
+});
+
 export const TraceEventSchema = Type.Union([
   Type.Object({
     type: Type.Literal("message"),
@@ -119,6 +172,45 @@ export const AgentRefSchema = Type.Object({
   name: Type.String(),
   role: Type.Optional(Type.String()),
   metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+export const AgentTurnSchema = Type.Object({
+  turn: TurnSchema,
+  agentId: Type.Optional(AgentIdSchema),
+});
+
+export const AgentLifecycleStatusSchema = Type.Union([
+  Type.Literal("completed"),
+  Type.Literal("timed_out"),
+  Type.Literal("failed_to_start"),
+  Type.Literal("runtime_error"),
+  Type.Literal("cancelled"),
+]);
+
+export const AgentOutcomeSchema = Type.Object({
+  agentId: AgentIdSchema,
+  status: AgentLifecycleStatusSchema,
+  startedAt: Type.Optional(Type.String()),
+  endedAt: Type.String(),
+  exitCode: Type.Optional(Type.Integer()),
+  reason: Type.Optional(Type.String()),
+});
+
+export const JudgmentBundleSchema = Type.Object({
+  runId: RunIdSchema,
+  project: ProjectIdSchema,
+  scenarioId: ScenarioIdSchema,
+  name: Type.String({ minLength: 1 }),
+  description: Type.String(),
+  requirements: RunRequirementsSchema,
+  agents: Type.Array(AgentRefSchema, { minItems: 1 }),
+  turns: Type.Optional(Type.Array(AgentTurnSchema)),
+  events: Type.Optional(Type.Array(TraceEventSchema)),
+  phases: Type.Optional(Type.Array(PhaseSchema)),
+  context: Type.Optional(UnknownRecordSchema),
+  workspaceDiff: Type.Optional(WorkspaceDiffSchema),
+  outcomes: Type.Array(AgentOutcomeSchema, { minItems: 1 }),
+  metadata: Type.Optional(UnknownRecordSchema),
 });
 
 // YAML-shaped Scenario. Function-valued deterministic checks cannot round-trip
@@ -333,7 +425,9 @@ export const PromptfooResultsSchema = Type.Object({
 export type IssueStatic = Static<typeof IssueSchema>;
 export type JudgeResultStatic = Static<typeof JudgeResultSchema>;
 export type RunRecordStatic = Static<typeof RunRecordSchema>;
+export type RunPlanStatic = Static<typeof RunPlanSchema>;
 export type TraceStatic = Static<typeof TraceSchema>;
+export type JudgmentBundleStatic = Static<typeof JudgmentBundleSchema>;
 
 // Helper: format TypeBox error list into short messages for the SchemaInvalid error cause.
 export function formatSchemaErrors(errors: Iterable<{ path: string; message: string }>): ReadonlyArray<string> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,10 +3,16 @@
 
 import { Brand } from "effect";
 
+export type ProjectId = string & Brand.Brand<"ProjectId">;
+export type RunId = string & Brand.Brand<"RunId">;
+export type AgentId = string & Brand.Brand<"AgentId">;
 export type ScenarioId = string & Brand.Brand<"ScenarioId">;
 export type TraceId = string & Brand.Brand<"TraceId">;
 export type RunNumber = number & Brand.Brand<"RunNumber">;
 
+export const ProjectId = Brand.nominal<ProjectId>();
+export const RunId = Brand.nominal<RunId>();
+export const AgentId = Brand.nominal<AgentId>();
 export const ScenarioId = Brand.nominal<ScenarioId>();
 export const TraceId = Brand.nominal<TraceId>();
 export const RunNumber = Brand.nominal<RunNumber>();
@@ -27,9 +33,10 @@ export const ISSUE_SEVERITY = {
   Critical: "critical",
 } as const satisfies { readonly [K in Capitalize<IssueSeverity>]: Uncapitalize<K> };
 
-export type RunSource = "scenario" | "trace";
+export type RunSource = "bundle" | "scenario" | "trace";
 
 export const RUN_SOURCE = {
+  Bundle: "bundle",
   Scenario: "scenario",
   Trace: "trace",
 } as const satisfies { readonly [K in Capitalize<RunSource>]: Uncapitalize<K> };
@@ -61,6 +68,51 @@ export interface WorkspaceFileChange {
 
 export interface WorkspaceDiff {
   readonly changed: ReadonlyArray<WorkspaceFileChange>;
+}
+
+export type ExecutionArtifact =
+  | {
+      readonly _tag: "DockerBuildArtifact";
+      readonly contextPath: string;
+      readonly dockerfilePath?: string;
+      readonly target?: string;
+      readonly buildArgs?: Readonly<Record<string, string>>;
+      readonly imageTag?: string;
+    }
+  | {
+      readonly _tag: "DockerImageArtifact";
+      readonly image: string;
+      readonly pullPolicy?: "always" | "if-missing" | "never";
+    };
+
+export const EXECUTION_ARTIFACT_TAG = {
+  DockerBuildArtifact: "DockerBuildArtifact",
+  DockerImageArtifact: "DockerImageArtifact",
+} as const satisfies { readonly [K in ExecutionArtifact["_tag"]]: K };
+
+export interface AgentDeclaration {
+  readonly id: AgentId;
+  readonly name: string;
+  readonly role?: string;
+  readonly artifact: ExecutionArtifact;
+  readonly promptInputs: Readonly<Record<string, unknown>>;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface RunRequirements {
+  readonly expectedBehavior: string;
+  readonly validationChecks: ReadonlyArray<string>;
+  readonly judgeRubric?: string;
+}
+
+export interface RunPlan {
+  readonly project: ProjectId;
+  readonly scenarioId: ScenarioId;
+  readonly name: string;
+  readonly description: string;
+  readonly agents: readonly [AgentDeclaration, ...AgentDeclaration[]];
+  readonly requirements: RunRequirements;
+  readonly metadata?: Readonly<Record<string, unknown>>;
 }
 
 export interface Turn {
@@ -97,9 +149,64 @@ export interface AgentRef {
   readonly metadata?: Readonly<Record<string, unknown>>;
 }
 
+export interface AgentTurn {
+  readonly turn: Turn;
+  readonly agentId?: AgentId;
+}
+
+export type AgentLifecycleStatus =
+  | "completed"
+  | "timed_out"
+  | "failed_to_start"
+  | "runtime_error"
+  | "cancelled";
+
+export const AGENT_LIFECYCLE_STATUS = {
+  Completed: "completed",
+  TimedOut: "timed_out",
+  FailedToStart: "failed_to_start",
+  RuntimeError: "runtime_error",
+  Cancelled: "cancelled",
+} as const;
+
+export interface AgentOutcome {
+  readonly agentId: AgentId;
+  readonly status: AgentLifecycleStatus;
+  readonly startedAt?: string;
+  readonly endedAt: string;
+  readonly exitCode?: number;
+  readonly reason?: string;
+}
+
+export interface JudgmentBundle {
+  readonly runId: RunId;
+  readonly project: ProjectId;
+  readonly scenarioId: ScenarioId;
+  readonly name: string;
+  readonly description: string;
+  readonly requirements: RunRequirements;
+  readonly agents: ReadonlyArray<AgentRef>;
+  readonly turns?: ReadonlyArray<AgentTurn>;
+  readonly events?: ReadonlyArray<TraceEvent>;
+  readonly phases?: ReadonlyArray<Phase>;
+  readonly context?: Readonly<Record<string, unknown>>;
+  readonly workspaceDiff?: WorkspaceDiff;
+  readonly outcomes: ReadonlyArray<AgentOutcome>;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
 export interface DeterministicCtx {
   readonly transcript: string;
   readonly diff: WorkspaceDiff;
+}
+
+export function agentRefFromDeclaration(agent: AgentDeclaration): AgentRef {
+  return {
+    id: agent.id,
+    name: agent.name,
+    ...(agent.role !== undefined ? { role: agent.role } : {}),
+    ...(agent.metadata !== undefined ? { metadata: agent.metadata } : {}),
+  };
 }
 
 // Utility: make unreachable branches a type error. Principle 4.

--- a/src/emit/bundle-codec.ts
+++ b/src/emit/bundle-codec.ts
@@ -1,0 +1,135 @@
+import { Effect } from "effect";
+import { Value } from "@sinclair/typebox/value";
+import * as YAML from "yaml";
+import { BundleDecodeError } from "../core/errors.js";
+import { JudgmentBundleSchema, formatSchemaErrors, type JudgmentBundleStatic } from "../core/schema.js";
+import {
+  AgentId,
+  ProjectId,
+  RunId,
+  ScenarioId,
+  type AgentOutcome,
+  type AgentRef,
+  type AgentTurn,
+  type JudgmentBundle as JudgmentBundleType,
+} from "../core/types.js";
+
+export interface BundleCodec {
+  readonly name: string;
+  encode(bundle: JudgmentBundleType): Effect.Effect<string, never, never>;
+  decode(source: string, originPath: string): Effect.Effect<JudgmentBundleType, BundleDecodeError, never>;
+}
+
+function decodeFromParsed(parsed: unknown, originPath: string): Effect.Effect<JudgmentBundleType, BundleDecodeError, never> {
+  const errors = formatSchemaErrors(Value.Errors(JudgmentBundleSchema, parsed));
+  if (errors.length > 0) {
+    return Effect.fail(
+      new BundleDecodeError({
+        cause: {
+          _tag: "SchemaInvalid",
+          path: originPath,
+          errors,
+        },
+      }),
+    );
+  }
+  const decoded = Value.Decode(JudgmentBundleSchema, parsed);
+  return Effect.succeed(normalizeBundle(decoded));
+}
+
+function normalizeBundle(decoded: JudgmentBundleStatic): JudgmentBundleType {
+  return {
+    runId: RunId(decoded.runId),
+    project: ProjectId(decoded.project),
+    scenarioId: ScenarioId(decoded.scenarioId),
+    name: decoded.name,
+    description: decoded.description,
+    requirements: decoded.requirements,
+    agents: decoded.agents.map(normalizeAgentRef),
+    ...(decoded.turns !== undefined ? { turns: decoded.turns.map(normalizeTurn) } : {}),
+    ...(decoded.events !== undefined ? { events: decoded.events } : {}),
+    ...(decoded.phases !== undefined ? { phases: decoded.phases } : {}),
+    ...(decoded.context !== undefined ? { context: decoded.context } : {}),
+    ...(decoded.workspaceDiff !== undefined ? { workspaceDiff: decoded.workspaceDiff } : {}),
+    outcomes: decoded.outcomes.map(normalizeOutcome),
+    ...(decoded.metadata !== undefined ? { metadata: decoded.metadata } : {}),
+  };
+}
+
+function normalizeAgentRef(agent: AgentRef): AgentRef {
+  return { ...agent };
+}
+
+function normalizeTurn(turn: NonNullable<JudgmentBundleStatic["turns"]>[number]): AgentTurn {
+  return {
+    turn: turn.turn,
+    ...(turn.agentId !== undefined ? { agentId: AgentId(turn.agentId) } : {}),
+  };
+}
+
+function normalizeOutcome(outcome: JudgmentBundleStatic["outcomes"][number]): AgentOutcome {
+  return {
+    ...outcome,
+    agentId: AgentId(outcome.agentId),
+  };
+}
+
+function decodeJson(source: string, originPath: string): Effect.Effect<JudgmentBundleType, BundleDecodeError, never> {
+  return Effect.try({
+    try: () => JSON.parse(source),
+    catch: (error) =>
+      new BundleDecodeError({
+        cause: {
+          _tag: "SchemaInvalid",
+          path: originPath,
+          errors: [error instanceof Error ? error.message : String(error)],
+        },
+      }),
+  }).pipe(Effect.flatMap((parsed) => decodeFromParsed(parsed, originPath)));
+}
+
+function decodeYaml(source: string, originPath: string): Effect.Effect<JudgmentBundleType, BundleDecodeError, never> {
+  return Effect.try({
+    try: () => YAML.parse(source),
+    catch: (error) =>
+      new BundleDecodeError({
+        cause: {
+          _tag: "SchemaInvalid",
+          path: originPath,
+          errors: [error instanceof Error ? error.message : String(error)],
+        },
+      }),
+  }).pipe(Effect.flatMap((parsed) => decodeFromParsed(parsed, originPath)));
+}
+
+function encodeJson(bundle: JudgmentBundleType): Effect.Effect<string, never, never> {
+  return Effect.sync(() => JSON.stringify(bundle, null, 2));
+}
+
+function encodeYaml(bundle: JudgmentBundleType): Effect.Effect<string, never, never> {
+  return Effect.sync(() => YAML.stringify(bundle));
+}
+
+export const bundleJsonCodec: BundleCodec = {
+  name: "json",
+  encode: encodeJson,
+  decode: decodeJson,
+};
+
+export const bundleYamlCodec: BundleCodec = {
+  name: "yaml",
+  encode: encodeYaml,
+  decode: decodeYaml,
+};
+
+export const bundleAutoCodec: BundleCodec = {
+  name: "auto",
+  encode: encodeJson,
+  decode(source, originPath) {
+    const trimmed = source.trimStart();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      return decodeJson(source, originPath);
+    }
+    return decodeYaml(source, originPath);
+  },
+};

--- a/src/emit/index.ts
+++ b/src/emit/index.ts
@@ -1,3 +1,4 @@
+export * from "./bundle-codec.js";
 export * from "./report.js";
 export * from "./observability.js";
 export * from "./trace-adapter.js";

--- a/src/judge/index.ts
+++ b/src/judge/index.ts
@@ -6,7 +6,17 @@
 import { Effect } from "effect";
 import { Value } from "@sinclair/typebox/value";
 import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
-import type { Turn, WorkspaceDiff, Issue, IssueSeverity, TraceEvent, Phase, AgentRef } from "../core/types.js";
+import type {
+  AgentRef,
+  AgentTurn,
+  Issue,
+  IssueSeverity,
+  JudgmentBundle,
+  Phase,
+  TraceEvent,
+  Turn,
+  WorkspaceDiff,
+} from "../core/types.js";
 import {
   type JudgeResult,
   type Scenario,
@@ -28,6 +38,8 @@ export interface JudgeBackend {
   readonly name: string;
   judge(input: JudgeInput): Effect.Effect<JudgeResult, never, never>;
 }
+
+export type JudgeBundleInput = JudgmentBundle;
 
 export interface AnthropicJudgeBackendOpts {
   readonly model?: string;
@@ -102,6 +114,92 @@ function renderEvents(events: ReadonlyArray<TraceEvent>): string {
 
 function renderAgents(agents: ReadonlyArray<AgentRef>): string {
   return agents.map((a) => `- ${a.name} (${a.id})${a.role ? ` role=${a.role}` : ""}`).join("\n");
+}
+
+function bundleToScenario(bundle: JudgmentBundle): Scenario {
+  return {
+    id: bundle.scenarioId,
+    name: bundle.name,
+    description: bundle.description,
+    setupPrompt: "",
+    expectedBehavior: bundle.requirements.expectedBehavior,
+    validationChecks: bundle.requirements.validationChecks,
+    ...(bundle.requirements.judgeRubric !== undefined ? { judgeRubric: bundle.requirements.judgeRubric } : {}),
+  };
+}
+
+function bundleTurnsToTurns(bundle: JudgmentBundle): ReadonlyArray<Turn> {
+  return bundle.turns?.map((entry) => entry.turn) ?? [];
+}
+
+function bundleTurnsToEvents(bundle: JudgmentBundle): ReadonlyArray<TraceEvent> | undefined {
+  if (bundle.events !== undefined && bundle.events.length > 0) {
+    return bundle.events;
+  }
+  if (bundle.turns === undefined || bundle.turns.length === 0) {
+    return undefined;
+  }
+  const agentNameById = new Map(bundle.agents.map((agent) => [agent.id, agent.name]));
+  const events: TraceEvent[] = [];
+  for (const entry of bundle.turns) {
+    events.push(...turnEntryToEvents(entry, agentNameById));
+  }
+  return events;
+}
+
+function turnEntryToEvents(
+  entry: AgentTurn,
+  agentNameById: ReadonlyMap<string, string>,
+): ReadonlyArray<TraceEvent> {
+  const promptTs = Date.parse(entry.turn.startedAt);
+  const safePromptTs = Number.isFinite(promptTs) ? promptTs : Date.now();
+  const agentId = entry.agentId;
+  const agentName = agentId !== undefined
+    ? (agentNameById.get(agentId) ?? agentId)
+    : "assistant";
+  return [
+    {
+      type: "message",
+      from: "user",
+      to: agentName,
+      channel: "prompt",
+      text: entry.turn.prompt,
+      ts: safePromptTs,
+    },
+    {
+      type: "message",
+      from: agentName,
+      channel: "response",
+      text: entry.turn.response,
+      ts: safePromptTs + entry.turn.latencyMs,
+    },
+  ];
+}
+
+export function bundleToJudgeInput(bundle: JudgmentBundle, abortSignal?: AbortSignal): JudgeInput {
+  const events = bundleTurnsToEvents(bundle);
+  const context = {
+    ...(bundle.context ?? {}),
+    agentOutcomes: bundle.outcomes,
+  };
+  return {
+    scenario: bundleToScenario(bundle),
+    turns: bundleTurnsToTurns(bundle),
+    ...(bundle.workspaceDiff !== undefined ? { workspaceDiff: bundle.workspaceDiff } : {}),
+    ...(events !== undefined ? { events } : {}),
+    ...(bundle.phases !== undefined ? { phases: bundle.phases } : {}),
+    ...(bundle.agents.length > 0 ? { agents: bundle.agents } : {}),
+    ...(Object.keys(context).length > 0 ? { context } : {}),
+    ...(abortSignal !== undefined ? { abortSignal } : {}),
+  };
+}
+
+export function judgeBundle(
+  backend: JudgeBackend,
+  bundle: JudgmentBundle,
+  abortSignal?: AbortSignal,
+): Effect.Effect<JudgeResult, never, never> {
+  return backend.judge(bundleToJudgeInput(bundle, abortSignal));
 }
 
 function renderPrompt(input: JudgeInput): string {

--- a/src/runner/coordinator.ts
+++ b/src/runner/coordinator.ts
@@ -1,6 +1,8 @@
 import { Effect } from "effect";
 import { Value } from "@sinclair/typebox/value";
+import { randomUUID } from "node:crypto";
 import {
+  AgentRunTimeoutError,
   AgentStartError,
   BundleBuildError,
   HarnessExecutionError,
@@ -49,7 +51,7 @@ export interface ExecutionHarness {
     execution: PreparedRunContext,
     sink: NormalizedBundleSink,
     opts: { readonly abortSignal?: AbortSignal },
-  ): Effect.Effect<void, HarnessExecutionError, never>;
+  ): Effect.Effect<void, HarnessExecutionError | AgentRunTimeoutError, never>;
 }
 
 export interface RunCoordinator {
@@ -83,9 +85,7 @@ export class DefaultRunCoordinator implements RunCoordinator {
     harness: ExecutionHarness,
     opts: RunCoordinatorOpts = {},
   ): Effect.Effect<JudgmentBundle, RunCoordinationError, never> {
-    const runId = RunId(
-      opts.runId ?? `${plan.project}:${plan.scenarioId}:${Date.now()}`,
-    );
+    const runId = RunId(opts.runId ?? randomUUID());
     const sink = makeNormalizedBundleSink(plan, runId);
     const handles: RuntimeHandle[] = [];
     const harnessOpts = opts.abortSignal !== undefined ? { abortSignal: opts.abortSignal } : {};
@@ -135,14 +135,15 @@ export class PromptWorkspaceHarness implements ExecutionHarness {
     plan: RunPlan,
     execution: PreparedRunContext,
     sink: NormalizedBundleSink,
-  ): Effect.Effect<void, HarnessExecutionError, never> {
+    opts: { readonly abortSignal?: AbortSignal },
+  ): Effect.Effect<void, HarnessExecutionError | AgentRunTimeoutError, never> {
     const config = this.#config;
     return Effect.gen(function* () {
       const perAgentDiffs = new Map<AgentId, WorkspaceDiff>();
       yield* Effect.forEach(
         plan.agents,
         (agent) =>
-          runPromptSequence(agent.id, execution, sink, config).pipe(
+          runPromptSequence(agent.id, execution, sink, config, opts.abortSignal).pipe(
             Effect.tap(({ diff }) =>
               Effect.sync(() => {
                 perAgentDiffs.set(agent.id, diff);
@@ -310,7 +311,8 @@ function runPromptSequence(
   execution: PreparedRunContext,
   sink: NormalizedBundleSink,
   config: PromptWorkspaceHarnessConfig,
-): Effect.Effect<{ readonly diff: WorkspaceDiff }, HarnessExecutionError, never> {
+  abortSignal: AbortSignal | undefined,
+): Effect.Effect<{ readonly diff: WorkspaceDiff }, HarnessExecutionError | AgentRunTimeoutError, never> {
   return Effect.gen(function* () {
     const handle = yield* execution.getHandle(agentId);
     if (config.workspace !== undefined && config.workspace.length > 0) {
@@ -322,9 +324,13 @@ function runPromptSequence(
       const result = yield* Effect.either(
         handle.executePrompt(prompt, {
           timeoutMs: config.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
+          ...(abortSignal !== undefined ? { abortSignal } : {}),
         }),
       );
       if (result._tag === "Left") {
+        if (abortSignal?.aborted === true) {
+          return yield* Effect.fail(result.left);
+        }
         const endedAt = new Date().toISOString();
         if (result.left._tag === "AgentRunTimeoutError") {
           yield* sink.recordOutcome({

--- a/src/runner/coordinator.ts
+++ b/src/runner/coordinator.ts
@@ -1,0 +1,491 @@
+import { Effect } from "effect";
+import { Value } from "@sinclair/typebox/value";
+import {
+  AgentStartError,
+  BundleBuildError,
+  HarnessExecutionError,
+  RunCoordinationError,
+  type BundleBuildCause,
+  type HarnessExecutionCause,
+} from "../core/errors.js";
+import { JudgmentBundleSchema, formatSchemaErrors } from "../core/schema.js";
+import {
+  AGENT_LIFECYCLE_STATUS,
+  AgentId,
+  RunId,
+  agentRefFromDeclaration,
+  type AgentOutcome,
+  type AgentTurn,
+  type JudgmentBundle,
+  type Phase,
+  type RunPlan,
+  type TraceEvent,
+  type WorkspaceDiff,
+  type WorkspaceFile,
+} from "../core/types.js";
+import { type AgentRuntime, type RuntimeHandle } from "./runtime.js";
+
+const DEFAULT_TURN_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface NormalizedBundleSink {
+  recordTurn(turn: AgentTurn): Effect.Effect<void, BundleBuildError, never>;
+  recordEvent(event: TraceEvent): Effect.Effect<void, BundleBuildError, never>;
+  recordPhase(phase: Phase): Effect.Effect<void, BundleBuildError, never>;
+  recordContextPatch(patch: Readonly<Record<string, unknown>>): Effect.Effect<void, BundleBuildError, never>;
+  setWorkspaceDiff(diff: WorkspaceDiff): Effect.Effect<void, BundleBuildError, never>;
+  recordOutcome(outcome: AgentOutcome): Effect.Effect<void, BundleBuildError, never>;
+  finalize(): Effect.Effect<JudgmentBundle, BundleBuildError, never>;
+}
+
+export interface PreparedRunContext {
+  readonly handles: ReadonlyMap<AgentId, RuntimeHandle>;
+  getHandle(agentId: AgentId): Effect.Effect<RuntimeHandle, HarnessExecutionError, never>;
+}
+
+export interface ExecutionHarness {
+  readonly name: string;
+  run(
+    plan: RunPlan,
+    execution: PreparedRunContext,
+    sink: NormalizedBundleSink,
+    opts: { readonly abortSignal?: AbortSignal },
+  ): Effect.Effect<void, HarnessExecutionError, never>;
+}
+
+export interface RunCoordinator {
+  execute(
+    plan: RunPlan,
+    harness: ExecutionHarness,
+    opts?: RunCoordinatorOpts,
+  ): Effect.Effect<JudgmentBundle, RunCoordinationError, never>;
+}
+
+export interface RunCoordinatorOpts {
+  readonly abortSignal?: AbortSignal;
+  readonly runId?: string;
+}
+
+export interface PromptWorkspaceHarnessConfig {
+  readonly prompts: readonly [string, ...string[]];
+  readonly workspace?: ReadonlyArray<WorkspaceFile>;
+  readonly turnTimeoutMs?: number;
+}
+
+export class DefaultRunCoordinator implements RunCoordinator {
+  readonly #runtime: AgentRuntime;
+
+  constructor(runtime: AgentRuntime) {
+    this.#runtime = runtime;
+  }
+
+  execute(
+    plan: RunPlan,
+    harness: ExecutionHarness,
+    opts: RunCoordinatorOpts = {},
+  ): Effect.Effect<JudgmentBundle, RunCoordinationError, never> {
+    const runId = RunId(
+      opts.runId ?? `${plan.project}:${plan.scenarioId}:${Date.now()}`,
+    );
+    const sink = makeNormalizedBundleSink(plan, runId);
+    const handles: RuntimeHandle[] = [];
+    const harnessOpts = opts.abortSignal !== undefined ? { abortSignal: opts.abortSignal } : {};
+
+    return Effect.forEach(
+      plan.agents,
+      (agent) =>
+        this.#runtime.prepare(agent, plan).pipe(
+          Effect.tap((handle) =>
+            Effect.sync(() => {
+              handles.push(handle);
+            }),
+          ),
+        ),
+      { concurrency: plan.agents.length },
+    ).pipe(
+      Effect.flatMap((preparedHandles) =>
+        harness.run(
+          plan,
+          makePreparedRunContext(preparedHandles),
+          sink,
+          harnessOpts,
+        ).pipe(
+          Effect.flatMap(() => sink.finalize()),
+        ),
+      ),
+      Effect.mapError((error) => mapRunCoordinationError(error)),
+      Effect.ensuring(
+        Effect.forEach(handles, (handle) => this.#runtime.stop(handle), {
+          concurrency: Math.max(1, handles.length),
+          discard: true,
+        }),
+      ),
+    );
+  }
+}
+
+export class PromptWorkspaceHarness implements ExecutionHarness {
+  readonly name = "prompt-workspace";
+  readonly #config: PromptWorkspaceHarnessConfig;
+
+  constructor(config: PromptWorkspaceHarnessConfig) {
+    this.#config = config;
+  }
+
+  run(
+    plan: RunPlan,
+    execution: PreparedRunContext,
+    sink: NormalizedBundleSink,
+  ): Effect.Effect<void, HarnessExecutionError, never> {
+    const config = this.#config;
+    return Effect.gen(function* () {
+      const perAgentDiffs = new Map<AgentId, WorkspaceDiff>();
+      yield* Effect.forEach(
+        plan.agents,
+        (agent) =>
+          runPromptSequence(agent.id, execution, sink, config).pipe(
+            Effect.tap(({ diff }) =>
+              Effect.sync(() => {
+                perAgentDiffs.set(agent.id, diff);
+              }),
+            ),
+          ),
+        { concurrency: plan.agents.length, discard: true },
+      );
+      if (plan.agents.length === 1) {
+        const onlyAgent = plan.agents[0];
+        const diff = onlyAgent !== undefined ? perAgentDiffs.get(onlyAgent.id) : undefined;
+        if (diff !== undefined) {
+          yield* sink.setWorkspaceDiff(diff).pipe(Effect.mapError(bundleBuildToHarness));
+        }
+        return;
+      }
+      const workspaceDiffByAgent = Object.fromEntries(perAgentDiffs.entries());
+      yield* sink.recordContextPatch({ workspaceDiffByAgent }).pipe(Effect.mapError(bundleBuildToHarness));
+    });
+  }
+}
+
+export function makeNormalizedBundleSink(
+  plan: RunPlan,
+  runId: string,
+): NormalizedBundleSink {
+  const turns: AgentTurn[] = [];
+  const events: TraceEvent[] = [];
+  const phases: Phase[] = [];
+  const outcomes = new Map<string, AgentOutcome>();
+  let context: Readonly<Record<string, unknown>> | undefined = plan.metadata;
+  let workspaceDiff: WorkspaceDiff | undefined = undefined;
+  const knownAgents = new Set(plan.agents.map((agent) => agent.id));
+
+  return {
+    recordTurn(turn) {
+      return Effect.sync(() => {
+        if (turn.agentId !== undefined && !knownAgents.has(turn.agentId)) {
+          throw new BundleBuildError({
+            cause: {
+              _tag: "UnknownAgent",
+              agentId: turn.agentId,
+            },
+          });
+        }
+        turns.push(turn);
+      }).pipe(Effect.catchAll(asBundleBuildError));
+    },
+
+    recordEvent(event) {
+      return Effect.sync(() => {
+        events.push(event);
+      }).pipe(Effect.catchAll(asBundleBuildError));
+    },
+
+    recordPhase(phase) {
+      return Effect.sync(() => {
+        phases.push(phase);
+      }).pipe(Effect.catchAll(asBundleBuildError));
+    },
+
+    recordContextPatch(patch) {
+      return Effect.sync(() => {
+        context = {
+          ...(context ?? {}),
+          ...patch,
+        };
+      }).pipe(Effect.catchAll(asBundleBuildError));
+    },
+
+    setWorkspaceDiff(diff) {
+      return Effect.sync(() => {
+        workspaceDiff = diff;
+      }).pipe(Effect.catchAll(asBundleBuildError));
+    },
+
+    recordOutcome(outcome) {
+      return Effect.sync(() => {
+        if (!knownAgents.has(outcome.agentId)) {
+          throw new BundleBuildError({
+            cause: {
+              _tag: "UnknownAgent",
+              agentId: outcome.agentId,
+            },
+          });
+        }
+        if (outcomes.has(outcome.agentId)) {
+          throw new BundleBuildError({
+            cause: {
+              _tag: "DuplicateOutcome",
+              agentId: outcome.agentId,
+            },
+          });
+        }
+        outcomes.set(outcome.agentId, outcome);
+      }).pipe(Effect.catchAll(asBundleBuildError));
+    },
+
+    finalize() {
+      return Effect.sync(() => {
+        const missingOutcomes = plan.agents
+          .map((agent) => agent.id)
+          .filter((agentId) => !outcomes.has(agentId));
+        if (missingOutcomes.length > 0) {
+          throw new BundleBuildError({
+            cause: {
+              _tag: "MissingOutcomes",
+              agentIds: missingOutcomes,
+            },
+          });
+        }
+        const bundle: JudgmentBundle = {
+          runId: RunId(runId),
+          project: plan.project,
+          scenarioId: plan.scenarioId,
+          name: plan.name,
+          description: plan.description,
+          requirements: plan.requirements,
+          agents: plan.agents.map(agentRefFromDeclaration),
+          ...(turns.length > 0 ? { turns: sortTurns(turns) } : {}),
+          ...(events.length > 0 ? { events: sortEvents(events) } : {}),
+          ...(phases.length > 0 ? { phases: sortPhases(phases) } : {}),
+          ...(context !== undefined && Object.keys(context).length > 0 ? { context } : {}),
+          ...(workspaceDiff !== undefined ? { workspaceDiff } : {}),
+          outcomes: Array.from(outcomes.values()),
+        };
+        const errors = formatSchemaErrors(Value.Errors(JudgmentBundleSchema, bundle));
+        if (errors.length > 0) {
+          throw new BundleBuildError({
+            cause: {
+              _tag: "SchemaInvalid",
+              errors,
+            },
+          });
+        }
+        return bundle;
+      }).pipe(Effect.catchAll(asBundleBuildError));
+    },
+  };
+}
+
+function makePreparedRunContext(handles: ReadonlyArray<RuntimeHandle>): PreparedRunContext {
+  const handleMap = new Map<AgentId, RuntimeHandle>(handles.map((handle) => [handle.agent.id, handle]));
+  return {
+    handles: handleMap,
+    getHandle(agentId) {
+      const handle = handleMap.get(agentId);
+      if (handle === undefined) {
+        return Effect.fail(
+          new HarnessExecutionError({
+            cause: {
+              _tag: "MissingRuntimeHandle",
+              agentId,
+            },
+          }),
+        );
+      }
+      return Effect.succeed(handle);
+    },
+  };
+}
+
+function runPromptSequence(
+  agentId: AgentId,
+  execution: PreparedRunContext,
+  sink: NormalizedBundleSink,
+  config: PromptWorkspaceHarnessConfig,
+): Effect.Effect<{ readonly diff: WorkspaceDiff }, HarnessExecutionError, never> {
+  return Effect.gen(function* () {
+    const handle = yield* execution.getHandle(agentId);
+    if (config.workspace !== undefined && config.workspace.length > 0) {
+      yield* handle.writeWorkspace(config.workspace);
+    }
+    const startedAt = new Date().toISOString();
+    let finishedWithFailure = false;
+    for (const prompt of config.prompts) {
+      const result = yield* Effect.either(
+        handle.executePrompt(prompt, {
+          timeoutMs: config.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
+        }),
+      );
+      if (result._tag === "Left") {
+        const endedAt = new Date().toISOString();
+        if (result.left._tag === "AgentRunTimeoutError") {
+          yield* sink.recordOutcome({
+            agentId,
+            status: AGENT_LIFECYCLE_STATUS.TimedOut,
+            startedAt,
+            endedAt,
+            reason: `agent timed out after ${String(result.left.timeoutMs)}ms`,
+          }).pipe(Effect.mapError(bundleBuildToHarness));
+        } else {
+          yield* sink.recordOutcome({
+            agentId,
+            status: AGENT_LIFECYCLE_STATUS.RuntimeError,
+            startedAt,
+            endedAt,
+            reason: renderHarnessCause(result.left.cause),
+          }).pipe(Effect.mapError(bundleBuildToHarness));
+        }
+        finishedWithFailure = true;
+        break;
+      }
+      const turn = result.right;
+      const promptTs = Date.parse(turn.startedAt);
+      const safePromptTs = Number.isFinite(promptTs) ? promptTs : Date.now();
+      yield* sink.recordTurn({
+        agentId,
+        turn,
+      }).pipe(Effect.mapError(bundleBuildToHarness));
+      yield* sink.recordEvent({
+        type: "message",
+        from: "user",
+        to: handle.agent.name,
+        channel: "prompt",
+        text: prompt,
+        ts: safePromptTs,
+      }).pipe(Effect.mapError(bundleBuildToHarness));
+      yield* sink.recordEvent({
+        type: "message",
+        from: handle.agent.name,
+        channel: "response",
+        text: turn.response,
+        ts: safePromptTs + turn.latencyMs,
+      }).pipe(Effect.mapError(bundleBuildToHarness));
+    }
+    const diff = yield* handle.diffWorkspace();
+    if (!finishedWithFailure) {
+      yield* sink.recordOutcome({
+        agentId,
+        status: AGENT_LIFECYCLE_STATUS.Completed,
+        startedAt,
+        endedAt: new Date().toISOString(),
+      }).pipe(Effect.mapError(bundleBuildToHarness));
+    }
+    return { diff };
+  });
+}
+
+function sortTurns(turns: ReadonlyArray<AgentTurn>): ReadonlyArray<AgentTurn> {
+  return [...turns].sort((left, right) => {
+    const leftTs = Date.parse(left.turn.startedAt);
+    const rightTs = Date.parse(right.turn.startedAt);
+    return leftTs - rightTs;
+  });
+}
+
+function sortEvents(events: ReadonlyArray<TraceEvent>): ReadonlyArray<TraceEvent> {
+  return [...events].sort((left, right) => left.ts - right.ts);
+}
+
+function sortPhases(phases: ReadonlyArray<Phase>): ReadonlyArray<Phase> {
+  return [...phases].sort((left, right) => left.tsStart - right.tsStart);
+}
+
+function asBundleBuildError(error: unknown): Effect.Effect<never, BundleBuildError, never> {
+  if (error instanceof BundleBuildError) {
+    return Effect.fail(error);
+  }
+  return Effect.fail(
+    new BundleBuildError({
+      cause: {
+        _tag: "SchemaInvalid",
+        errors: [error instanceof Error ? error.message : String(error)],
+      },
+    }),
+  );
+}
+
+function mapRunCoordinationError(error: unknown): RunCoordinationError {
+  if (error instanceof RunCoordinationError) {
+    return error;
+  }
+  if (error instanceof BundleBuildError) {
+    return new RunCoordinationError({
+      cause: {
+        _tag: "BundleBuildFailed",
+        detail: error.cause,
+      },
+    });
+  }
+  if (error instanceof HarnessExecutionError) {
+    return new RunCoordinationError({
+      cause: {
+        _tag: "HarnessFailed",
+        detail: error.cause,
+      },
+    });
+  }
+  if (error instanceof AgentStartError) {
+    return new RunCoordinationError({
+      cause: {
+        _tag: "AgentStartFailed",
+        agentId: error.agentId ?? "unknown-agent",
+        detail: error.cause,
+      },
+    });
+  }
+  return new RunCoordinationError({
+    cause: {
+      _tag: "HarnessFailed",
+      detail: {
+        _tag: "ExecutionFailed",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    },
+  });
+}
+
+function bundleBuildToHarness(error: BundleBuildError): HarnessExecutionError {
+  return new HarnessExecutionError({
+    cause: {
+      _tag: "ExecutionFailed",
+      message: renderBundleBuildCause(error.cause),
+    },
+  });
+}
+
+function renderBundleBuildCause(cause: BundleBuildCause): string {
+  switch (cause._tag) {
+    case "DuplicateOutcome":
+      return `duplicate outcome for ${cause.agentId}`;
+    case "MissingOutcomes":
+      return `missing outcomes for ${cause.agentIds.join(", ")}`;
+    case "UnknownAgent":
+      return `unknown agent ${cause.agentId}`;
+    case "EventOrderViolation":
+      return `event order violated: ${String(cause.previousTs)} > ${String(cause.nextTs)}`;
+    case "SchemaInvalid":
+      return `bundle schema invalid: ${cause.errors.join("; ")}`;
+  }
+}
+
+function renderHarnessCause(cause: HarnessExecutionCause): string {
+  switch (cause._tag) {
+    case "MissingRuntimeHandle":
+      return `missing runtime handle for ${cause.agentId}`;
+    case "InvalidPlanMetadata":
+      return cause.message;
+    case "ExecutionFailed":
+      return cause.message;
+  }
+}
+
+void AGENT_LIFECYCLE_STATUS.Cancelled;
+void AGENT_LIFECYCLE_STATUS.FailedToStart;

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -1,6 +1,9 @@
 // AgentRunner interface + bundled DockerRunner, SubprocessRunner.
 // Invariant: stop() never fails (teardown is crash-only).
 
+export * from "./runtime.js";
+export * from "./coordinator.js";
+
 import { Effect } from "effect";
 import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";

--- a/src/runner/runtime.ts
+++ b/src/runner/runtime.ts
@@ -1,0 +1,844 @@
+import { Effect } from "effect";
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  AgentRunTimeoutError,
+  AgentStartError,
+  HarnessExecutionError,
+} from "../core/errors.js";
+import type {
+  AgentDeclaration,
+  RuntimeKind,
+  RunPlan,
+  Turn,
+  WorkspaceDiff,
+  WorkspaceFile,
+  WorkspaceFileChange,
+} from "../core/types.js";
+
+const DEFAULT_CLAUDE_ARGS: ReadonlyArray<string> = ["-p", "--output-format", "stream-json", "--verbose"];
+
+interface MutableWorkspaceState {
+  readonly baselineFiles: Map<string, string>;
+  turnsExecuted: number;
+}
+
+export interface RuntimeHandle {
+  readonly agent: AgentDeclaration;
+  readonly kind: RuntimeKind;
+  readonly workspaceDir: string;
+  writeWorkspace(files: ReadonlyArray<WorkspaceFile>): Effect.Effect<void, HarnessExecutionError, never>;
+  executePrompt(
+    prompt: string,
+    opts: { readonly timeoutMs: number },
+  ): Effect.Effect<Turn, AgentRunTimeoutError | HarnessExecutionError, never>;
+  diffWorkspace(): Effect.Effect<WorkspaceDiff, never, never>;
+}
+
+export interface AgentRuntime {
+  readonly kind: RuntimeKind;
+  prepare(agent: AgentDeclaration, plan: RunPlan): Effect.Effect<RuntimeHandle, AgentStartError, never>;
+  stop(handle: RuntimeHandle): Effect.Effect<void, never, never>;
+}
+
+export interface DockerRuntimeOpts {
+  readonly network?: "none" | "bridge";
+  readonly memoryMb?: number;
+  readonly cpus?: number;
+  readonly claudeArgs?: ReadonlyArray<string>;
+}
+
+export interface SubprocessRuntimeOpts {
+  readonly bin: string;
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly extraArgs?: ReadonlyArray<string>;
+}
+
+interface ParsedTurn {
+  readonly response: string;
+  readonly toolCallCount: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+}
+
+interface StreamJsonEvent {
+  readonly type?: unknown;
+  readonly content?: unknown;
+  readonly result?: unknown;
+  readonly usage?: unknown;
+}
+
+interface StreamJsonUsage {
+  readonly input_tokens?: unknown;
+  readonly output_tokens?: unknown;
+  readonly cache_read_input_tokens?: unknown;
+  readonly cache_creation_input_tokens?: unknown;
+}
+
+interface PreparedImage {
+  readonly image: string;
+  readonly removeOnStop: boolean;
+}
+
+class PathEscapeSignal {
+  constructor(readonly wfPath: string) {}
+}
+
+export class DockerRuntime implements AgentRuntime {
+  readonly kind: "docker" = "docker";
+  readonly #opts: DockerRuntimeOpts;
+
+  constructor(opts: DockerRuntimeOpts = {}) {
+    this.#opts = opts;
+  }
+
+  prepare(agent: AgentDeclaration, plan: RunPlan): Effect.Effect<RuntimeHandle, AgentStartError, never> {
+    const runtimeOpts = this.#opts;
+    return Effect.gen(function* () {
+      const preparedImage = yield* materializeImage(agent, plan);
+      const workspace = yield* makeEmptyWorkspace(plan.scenarioId);
+      const containerId = yield* createDockerContainer(preparedImage.image, workspace.dir, runtimeOpts, plan, agent);
+      return createDockerHandle({
+        agent,
+        plan,
+        workspaceDir: workspace.dir,
+        state: workspace.state,
+        containerId,
+        claudeArgs: runtimeOpts.claudeArgs ?? DEFAULT_CLAUDE_ARGS,
+        preparedImage,
+      });
+    });
+  }
+
+  stop(handle: RuntimeHandle): Effect.Effect<void, never, never> {
+    return Effect.sync(() => {
+      const dockerHandle = handle as RuntimeHandle & {
+        readonly containerId?: string;
+        readonly preparedImage?: PreparedImage;
+      };
+      if (dockerHandle.containerId !== undefined && dockerHandle.containerId.length > 0) {
+        try {
+          execSync(`docker kill ${shellQuote(dockerHandle.containerId)}`, { stdio: "ignore" });
+        } catch (error) {
+          void error;
+        }
+        try {
+          execSync(`docker rm -f ${shellQuote(dockerHandle.containerId)}`, { stdio: "ignore" });
+        } catch (error) {
+          void error;
+        }
+      }
+      try {
+        rmSync(handle.workspaceDir, { recursive: true, force: true });
+      } catch (error) {
+        void error;
+      }
+      if (dockerHandle.preparedImage?.removeOnStop === true) {
+        try {
+          execSync(`docker image rm -f ${shellQuote(dockerHandle.preparedImage.image)}`, { stdio: "ignore" });
+        } catch (error) {
+          void error;
+        }
+      }
+    });
+  }
+}
+
+export class SubprocessRuntime implements AgentRuntime {
+  readonly kind: "subprocess" = "subprocess";
+  readonly #opts: SubprocessRuntimeOpts;
+
+  constructor(opts: SubprocessRuntimeOpts) {
+    this.#opts = opts;
+  }
+
+  prepare(agent: AgentDeclaration, plan: RunPlan): Effect.Effect<RuntimeHandle, AgentStartError, never> {
+    return Effect.suspend(() => {
+      if (!existsSync(this.#opts.bin)) {
+        return Effect.fail(
+          new AgentStartError({
+            scenarioId: plan.scenarioId,
+            agentId: agent.id,
+            cause: {
+              _tag: "BinaryNotFound",
+              path: this.#opts.bin,
+            },
+          }),
+        );
+      }
+      return makeEmptyWorkspace(plan.scenarioId).pipe(
+        Effect.map(({ dir, state }) =>
+          createSubprocessHandle({
+            agent,
+            plan,
+            workspaceDir: dir,
+            state,
+            opts: this.#opts,
+          }),
+        ),
+      );
+    });
+  }
+
+  stop(handle: RuntimeHandle): Effect.Effect<void, never, never> {
+    return Effect.sync(() => {
+      try {
+        rmSync(handle.workspaceDir, { recursive: true, force: true });
+      } catch (error) {
+        void error;
+      }
+    });
+  }
+}
+
+function makeEmptyWorkspace(
+  scenarioId: RunPlan["scenarioId"],
+): Effect.Effect<{ readonly dir: string; readonly state: MutableWorkspaceState }, AgentStartError, never> {
+  return Effect.try({
+    try: () => {
+      const dir = mkdtempSync(path.join(os.tmpdir(), `cc-judge-${scenarioId}-`));
+      return {
+        dir,
+        state: {
+          baselineFiles: new Map<string, string>(),
+          turnsExecuted: 0,
+        },
+      };
+    },
+    catch: (error) =>
+      new AgentStartError({
+        scenarioId,
+        cause: {
+          _tag: "WorkspaceSetupFailed",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      }),
+  });
+}
+
+function createDockerHandle(params: {
+  readonly agent: AgentDeclaration;
+  readonly plan: RunPlan;
+  readonly workspaceDir: string;
+  readonly state: MutableWorkspaceState;
+  readonly containerId: string;
+  readonly claudeArgs: ReadonlyArray<string>;
+  readonly preparedImage: PreparedImage;
+}): RuntimeHandle {
+  return {
+    agent: params.agent,
+    kind: "docker",
+    workspaceDir: params.workspaceDir,
+    containerId: params.containerId,
+    preparedImage: params.preparedImage,
+    writeWorkspace(files) {
+      return writeWorkspaceFiles(params.workspaceDir, params.state, files, params.plan, params.agent);
+    },
+    executePrompt(prompt, opts) {
+      return runDockerPrompt(
+        params.containerId,
+        params.plan,
+        params.agent,
+        params.state,
+        params.claudeArgs,
+        prompt,
+        opts.timeoutMs,
+      );
+    },
+    diffWorkspace() {
+      return diffWorkspace(params.workspaceDir, params.state);
+    },
+  } as RuntimeHandle;
+}
+
+function createSubprocessHandle(params: {
+  readonly agent: AgentDeclaration;
+  readonly plan: RunPlan;
+  readonly workspaceDir: string;
+  readonly state: MutableWorkspaceState;
+  readonly opts: SubprocessRuntimeOpts;
+}): RuntimeHandle {
+  return {
+    agent: params.agent,
+    kind: "subprocess",
+    workspaceDir: params.workspaceDir,
+    writeWorkspace(files) {
+      return writeWorkspaceFiles(params.workspaceDir, params.state, files, params.plan, params.agent);
+    },
+    executePrompt(prompt, opts) {
+      return runSubprocessPrompt(params.plan, params.agent, params.state, params.workspaceDir, params.opts, prompt, opts.timeoutMs);
+    },
+    diffWorkspace() {
+      return diffWorkspace(params.workspaceDir, params.state);
+    },
+  };
+}
+
+function writeWorkspaceFiles(
+  workspaceDir: string,
+  state: MutableWorkspaceState,
+  files: ReadonlyArray<WorkspaceFile>,
+  plan: RunPlan,
+  agent: AgentDeclaration,
+): Effect.Effect<void, HarnessExecutionError, never> {
+  return Effect.try({
+    try: () => {
+      const rootResolved = path.resolve(workspaceDir);
+      for (const file of files) {
+        const abs = path.resolve(rootResolved, file.path);
+        const rel = path.relative(rootResolved, abs);
+        if (rel.startsWith("..") || path.isAbsolute(rel)) {
+          throw new PathEscapeSignal(file.path);
+        }
+        mkdirSync(path.dirname(abs), { recursive: true });
+        writeFileSync(abs, file.content, "utf8");
+        state.baselineFiles.set(file.path, file.content);
+      }
+    },
+    catch: (error) =>
+      new HarnessExecutionError({
+        cause: {
+          _tag: "ExecutionFailed",
+          message: error instanceof PathEscapeSignal
+            ? `workspace path escapes root for agent ${agent.id}: ${error.wfPath}`
+            : `${plan.scenarioId} workspace write failed: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      }),
+  });
+}
+
+function diffWorkspace(
+  workspaceDir: string,
+  state: MutableWorkspaceState,
+): Effect.Effect<WorkspaceDiff, never, never> {
+  return walkWorkspace(workspaceDir).pipe(
+    Effect.map((current) => computeDiff(state.baselineFiles, current)),
+  );
+}
+
+function runDockerPrompt(
+  containerId: string,
+  plan: RunPlan,
+  agent: AgentDeclaration,
+  state: MutableWorkspaceState,
+  claudeArgs: ReadonlyArray<string>,
+  prompt: string,
+  timeoutMs: number,
+): Effect.Effect<Turn, AgentRunTimeoutError | HarnessExecutionError, never> {
+  return runPromptProcess({
+    cmd: "docker",
+    args: ["exec", containerId, "claude", ...claudeArgs, prompt],
+    plan,
+    agent,
+    state,
+    prompt,
+    timeoutMs,
+  });
+}
+
+function runSubprocessPrompt(
+  plan: RunPlan,
+  agent: AgentDeclaration,
+  state: MutableWorkspaceState,
+  workspaceDir: string,
+  opts: SubprocessRuntimeOpts,
+  prompt: string,
+  timeoutMs: number,
+): Effect.Effect<Turn, AgentRunTimeoutError | HarnessExecutionError, never> {
+  const args = [...(opts.extraArgs ?? DEFAULT_CLAUDE_ARGS), prompt];
+  const env = opts.env !== undefined ? { ...process.env, ...opts.env } : process.env;
+  return runPromptProcess({
+    cmd: opts.bin,
+    args,
+    cwd: opts.cwd ?? workspaceDir,
+    env,
+    plan,
+    agent,
+    state,
+    prompt,
+    timeoutMs,
+  });
+}
+
+function runPromptProcess(params: {
+  readonly cmd: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly plan: RunPlan;
+  readonly agent: AgentDeclaration;
+  readonly state: MutableWorkspaceState;
+  readonly prompt: string;
+  readonly timeoutMs: number;
+}): Effect.Effect<Turn, AgentRunTimeoutError | HarnessExecutionError, never> {
+  return Effect.async((resume) => {
+    let finished = false;
+    const turnIndex = params.state.turnsExecuted;
+    const startedAt = new Date().toISOString();
+    const startMs = Date.now();
+    const child: ChildProcess = spawn(params.cmd, [...params.args], {
+      cwd: params.cwd,
+      env: params.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    const timer = setTimeout(() => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      try {
+        child.kill("SIGKILL");
+      } catch (error) {
+        void error;
+      }
+      resume(
+        Effect.fail(
+          new AgentRunTimeoutError({
+            scenarioId: params.plan.scenarioId,
+            turnIndex,
+            timeoutMs: params.timeoutMs,
+          }),
+        ),
+      );
+    }, params.timeoutMs);
+    child.on("close", () => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      clearTimeout(timer);
+      params.state.turnsExecuted += 1;
+      const parsed = parseStreamJson(stdout);
+      const responseText = parsed.response.length > 0 ? parsed.response : stderr;
+      resume(
+        Effect.succeed({
+          index: turnIndex,
+          prompt: params.prompt,
+          response: responseText,
+          startedAt,
+          latencyMs: Date.now() - startMs,
+          toolCallCount: parsed.toolCallCount,
+          inputTokens: parsed.inputTokens,
+          outputTokens: parsed.outputTokens,
+          cacheReadTokens: parsed.cacheReadTokens,
+          cacheWriteTokens: parsed.cacheWriteTokens,
+        }),
+      );
+    });
+    child.on("error", (error) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      clearTimeout(timer);
+      resume(
+        Effect.fail(
+          new HarnessExecutionError({
+            cause: {
+              _tag: "ExecutionFailed",
+              message: `${params.agent.id} prompt execution failed: ${error.message}`,
+            },
+          }),
+        ),
+      );
+    });
+    return Effect.sync(() => {
+      clearTimeout(timer);
+      try {
+        child.kill("SIGKILL");
+      } catch (error) {
+        void error;
+      }
+    });
+  });
+}
+
+function materializeImage(
+  agent: AgentDeclaration,
+  plan: RunPlan,
+): Effect.Effect<PreparedImage, AgentStartError, never> {
+  switch (agent.artifact._tag) {
+    case "DockerBuildArtifact":
+      return buildDockerImage(agent, plan);
+    case "DockerImageArtifact":
+      return ensureDockerImage(agent, plan);
+  }
+}
+
+function buildDockerImage(
+  agent: AgentDeclaration,
+  plan: RunPlan,
+): Effect.Effect<PreparedImage, AgentStartError, never> {
+  const artifact = agent.artifact;
+  if (artifact._tag !== "DockerBuildArtifact") {
+    return Effect.fail(
+      new AgentStartError({
+        scenarioId: plan.scenarioId,
+        agentId: agent.id,
+        cause: {
+          _tag: "DockerBuildFailed",
+          message: `expected DockerBuildArtifact, received ${artifact._tag}`,
+        },
+      }),
+    );
+  }
+  return Effect.try({
+    try: () => {
+      const contextPath = path.resolve(artifact.contextPath);
+      if (!existsSync(contextPath)) {
+        throw new AgentStartError({
+          scenarioId: plan.scenarioId,
+          agentId: agent.id,
+          cause: {
+            _tag: "BuildContextMissing",
+            path: contextPath,
+          },
+        });
+      }
+      const autoTag = `cc-judge-${sanitizeId(plan.scenarioId)}-${sanitizeId(agent.id)}-${Date.now()}`;
+      const imageTag = artifact.imageTag ?? autoTag;
+      const args = [
+        "build",
+        "-t",
+        imageTag,
+        ...(artifact.dockerfilePath !== undefined ? ["-f", artifact.dockerfilePath] : []),
+        ...(artifact.target !== undefined ? ["--target", artifact.target] : []),
+        ...renderBuildArgs(artifact.buildArgs),
+        contextPath,
+      ];
+      execSync(`docker ${args.map(shellQuote).join(" ")}`, { stdio: "pipe" });
+      return {
+        image: imageTag,
+        removeOnStop: artifact.imageTag === undefined,
+      };
+    },
+    catch: (error) => {
+      if (error instanceof AgentStartError) {
+        return error;
+      }
+      return new AgentStartError({
+        scenarioId: plan.scenarioId,
+        agentId: agent.id,
+        cause: {
+          _tag: "DockerBuildFailed",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      });
+    },
+  });
+}
+
+function ensureDockerImage(
+  agent: AgentDeclaration,
+  plan: RunPlan,
+): Effect.Effect<PreparedImage, AgentStartError, never> {
+  const artifact = agent.artifact;
+  if (artifact._tag !== "DockerImageArtifact") {
+    return Effect.fail(
+      new AgentStartError({
+        scenarioId: plan.scenarioId,
+        agentId: agent.id,
+        cause: {
+          _tag: "ImageMissing",
+          image: `invalid-artifact:${artifact._tag}`,
+        },
+      }),
+    );
+  }
+  return Effect.try({
+    try: () => {
+      const image = artifact.image;
+      const pullPolicy = artifact.pullPolicy ?? "if-missing";
+      const imageAvailable = dockerImageExists(image);
+      if (pullPolicy === "always" || (pullPolicy === "if-missing" && !imageAvailable)) {
+        try {
+          execSync(`docker pull ${shellQuote(image)}`, { stdio: "pipe" });
+        } catch (error) {
+          throw new AgentStartError({
+            scenarioId: plan.scenarioId,
+            agentId: agent.id,
+            cause: {
+              _tag: "ImagePullFailed",
+              image,
+              message: error instanceof Error ? error.message : String(error),
+            },
+          });
+        }
+      }
+      if (pullPolicy === "never" && !imageAvailable) {
+        throw new AgentStartError({
+          scenarioId: plan.scenarioId,
+          agentId: agent.id,
+          cause: {
+            _tag: "ImageMissing",
+            image,
+          },
+        });
+      }
+      if (!dockerImageExists(image)) {
+        throw new AgentStartError({
+          scenarioId: plan.scenarioId,
+          agentId: agent.id,
+          cause: {
+            _tag: "ImageMissing",
+            image,
+          },
+        });
+      }
+      return {
+        image,
+        removeOnStop: false,
+      };
+    },
+    catch: (error) => {
+      if (error instanceof AgentStartError) {
+        return error;
+      }
+      return new AgentStartError({
+        scenarioId: plan.scenarioId,
+        agentId: agent.id,
+        cause: {
+          _tag: "ImageMissing",
+          image: artifact.image,
+        },
+      });
+    },
+  });
+}
+
+function createDockerContainer(
+  image: string,
+  workspaceDir: string,
+  opts: DockerRuntimeOpts,
+  plan: RunPlan,
+  agent: AgentDeclaration,
+): Effect.Effect<string, AgentStartError, never> {
+  return Effect.try({
+    try: () => {
+      const args = [
+        "create",
+        "--rm",
+        "-v",
+        `${workspaceDir}:/workspace`,
+        "-w",
+        "/workspace",
+        "--network",
+        opts.network ?? "none",
+        ...(opts.memoryMb !== undefined ? ["--memory", `${opts.memoryMb}m`] : []),
+        ...(opts.cpus !== undefined ? ["--cpus", String(opts.cpus)] : []),
+        image,
+        "tail",
+        "-f",
+        "/dev/null",
+      ];
+      const containerId = execSync(`docker ${args.map(shellQuote).join(" ")}`, { stdio: "pipe" })
+        .toString("utf8")
+        .trim();
+      execSync(`docker start ${shellQuote(containerId)}`, { stdio: "ignore" });
+      return containerId;
+    },
+    catch: (error) =>
+      new AgentStartError({
+        scenarioId: plan.scenarioId,
+        agentId: agent.id,
+        cause: {
+          _tag: "ContainerStartFailed",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      }),
+  });
+}
+
+function parseStreamJson(stdout: string): ParsedTurn {
+  let response = "";
+  let toolCallCount = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+  let sawStructured = false;
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      void error;
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      continue;
+    }
+    sawStructured = true;
+    const obj: StreamJsonEvent = parsed;
+    const type = typeof obj.type === "string" ? obj.type : "";
+    switch (type) {
+      case "assistant":
+        if (typeof obj.content === "string") {
+          response += obj.content;
+        }
+        break;
+      case "result":
+        if (typeof obj.result === "string" && response.length === 0) {
+          response = obj.result;
+        }
+        break;
+      case "tool_use":
+      case "tool_call":
+        toolCallCount += 1;
+        break;
+      default:
+        break;
+    }
+    const usage = obj.usage;
+    if (typeof usage === "object" && usage !== null) {
+      const tokens: StreamJsonUsage = usage;
+      if (typeof tokens.input_tokens === "number") {
+        inputTokens += tokens.input_tokens;
+      }
+      if (typeof tokens.output_tokens === "number") {
+        outputTokens += tokens.output_tokens;
+      }
+      if (typeof tokens.cache_read_input_tokens === "number") {
+        cacheReadTokens += tokens.cache_read_input_tokens;
+      }
+      if (typeof tokens.cache_creation_input_tokens === "number") {
+        cacheWriteTokens += tokens.cache_creation_input_tokens;
+      }
+    }
+  }
+  if (!sawStructured) {
+    response = stdout;
+  }
+  return {
+    response,
+    toolCallCount,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+  };
+}
+
+function walkWorkspace(dir: string): Effect.Effect<ReadonlyMap<string, string>, never, never> {
+  const output = new Map<string, string>();
+  return walkInto(dir, dir, output).pipe(Effect.map(() => output as ReadonlyMap<string, string>));
+}
+
+function walkInto(
+  root: string,
+  currentDir: string,
+  output: Map<string, string>,
+): Effect.Effect<void, never, never> {
+  return Effect.tryPromise({
+    try: () => readdir(currentDir, { withFileTypes: true }),
+    catch: () => [],
+  }).pipe(
+    Effect.catchAll(() => Effect.succeed([])),
+    Effect.flatMap((entries) =>
+      Effect.forEach(
+        entries,
+        (entry) => {
+          const absolutePath = path.join(currentDir, entry.name);
+          if (entry.isDirectory()) {
+            return walkInto(root, absolutePath, output);
+          }
+          if (!entry.isFile()) {
+            return Effect.void;
+          }
+          return Effect.tryPromise({
+            try: () => readFile(absolutePath, "utf8"),
+            catch: () => null,
+          }).pipe(
+            Effect.match({
+              onFailure: () => undefined,
+              onSuccess: (content: string | null) => {
+                if (content !== null) {
+                  output.set(path.relative(root, absolutePath), content);
+                }
+              },
+            }),
+          );
+        },
+        { discard: true },
+      ),
+    ),
+  );
+}
+
+function computeDiff(
+  baseline: ReadonlyMap<string, string>,
+  current: ReadonlyMap<string, string>,
+): WorkspaceDiff {
+  const changed: WorkspaceFileChange[] = [];
+  const seen = new Set<string>();
+  for (const [relativePath, before] of baseline) {
+    seen.add(relativePath);
+    const after = current.get(relativePath);
+    if (after === undefined) {
+      changed.push({ path: relativePath, before, after: null });
+    } else if (after !== before) {
+      changed.push({ path: relativePath, before, after });
+    }
+  }
+  for (const [relativePath, after] of current) {
+    if (!seen.has(relativePath)) {
+      changed.push({ path: relativePath, before: null, after });
+    }
+  }
+  return { changed };
+}
+
+function dockerImageExists(image: string): boolean {
+  try {
+    execSync(`docker image inspect ${shellQuote(image)}`, { stdio: "ignore" });
+    return true;
+  } catch (error) {
+    void error;
+    return false;
+  }
+}
+
+function renderBuildArgs(buildArgs: Readonly<Record<string, string>> | undefined): ReadonlyArray<string> {
+  if (buildArgs === undefined) {
+    return [];
+  }
+  return Object.entries(buildArgs).flatMap(([key, value]) => ["--build-arg", `${key}=${value}`]);
+}
+
+function sanitizeId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/gu, "-");
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_:@./=-]+$/u.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+void readFileSync;

--- a/src/runner/runtime.ts
+++ b/src/runner/runtime.ts
@@ -40,7 +40,7 @@ export interface RuntimeHandle {
   writeWorkspace(files: ReadonlyArray<WorkspaceFile>): Effect.Effect<void, HarnessExecutionError, never>;
   executePrompt(
     prompt: string,
-    opts: { readonly timeoutMs: number },
+    opts: { readonly timeoutMs: number; readonly abortSignal?: AbortSignal },
   ): Effect.Effect<Turn, AgentRunTimeoutError | HarnessExecutionError, never>;
   diffWorkspace(): Effect.Effect<WorkspaceDiff, never, never>;
 }
@@ -256,6 +256,7 @@ function createDockerHandle(params: {
         params.claudeArgs,
         prompt,
         opts.timeoutMs,
+        opts.abortSignal,
       );
     },
     diffWorkspace() {
@@ -279,7 +280,16 @@ function createSubprocessHandle(params: {
       return writeWorkspaceFiles(params.workspaceDir, params.state, files, params.plan, params.agent);
     },
     executePrompt(prompt, opts) {
-      return runSubprocessPrompt(params.plan, params.agent, params.state, params.workspaceDir, params.opts, prompt, opts.timeoutMs);
+      return runSubprocessPrompt(
+        params.plan,
+        params.agent,
+        params.state,
+        params.workspaceDir,
+        params.opts,
+        prompt,
+        opts.timeoutMs,
+        opts.abortSignal,
+      );
     },
     diffWorkspace() {
       return diffWorkspace(params.workspaceDir, params.state);
@@ -337,17 +347,19 @@ function runDockerPrompt(
   claudeArgs: ReadonlyArray<string>,
   prompt: string,
   timeoutMs: number,
+  abortSignal?: AbortSignal,
 ): Effect.Effect<Turn, AgentRunTimeoutError | HarnessExecutionError, never> {
-  return runPromptProcess({
-    cmd: "docker",
-    args: ["exec", containerId, "claude", ...claudeArgs, prompt],
-    plan,
-    agent,
-    state,
-    prompt,
-    timeoutMs,
-  });
-}
+    return runPromptProcess({
+      cmd: "docker",
+      args: ["exec", containerId, "claude", ...claudeArgs, prompt],
+      plan,
+      agent,
+      state,
+      prompt,
+      timeoutMs,
+      ...(abortSignal !== undefined ? { abortSignal } : {}),
+    });
+  }
 
 function runSubprocessPrompt(
   plan: RunPlan,
@@ -357,6 +369,7 @@ function runSubprocessPrompt(
   opts: SubprocessRuntimeOpts,
   prompt: string,
   timeoutMs: number,
+  abortSignal?: AbortSignal,
 ): Effect.Effect<Turn, AgentRunTimeoutError | HarnessExecutionError, never> {
   const args = [...(opts.extraArgs ?? DEFAULT_CLAUDE_ARGS), prompt];
   const env = opts.env !== undefined ? { ...process.env, ...opts.env } : process.env;
@@ -370,6 +383,7 @@ function runSubprocessPrompt(
     state,
     prompt,
     timeoutMs,
+    ...(abortSignal !== undefined ? { abortSignal } : {}),
   });
 }
 
@@ -383,12 +397,14 @@ function runPromptProcess(params: {
   readonly state: MutableWorkspaceState;
   readonly prompt: string;
   readonly timeoutMs: number;
+  readonly abortSignal?: AbortSignal;
 }): Effect.Effect<Turn, AgentRunTimeoutError | HarnessExecutionError, never> {
-  return Effect.async((resume) => {
+  return Effect.async((resume, signal) => {
     let finished = false;
     const turnIndex = params.state.turnsExecuted;
     const startedAt = new Date().toISOString();
     const startMs = Date.now();
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const child: ChildProcess = spawn(params.cmd, [...params.args], {
       cwd: params.cwd,
       env: params.env,
@@ -396,22 +412,54 @@ function runPromptProcess(params: {
     });
     let stdout = "";
     let stderr = "";
+    const abortError = () =>
+      new HarnessExecutionError({
+        cause: {
+          _tag: "ExecutionFailed",
+          message: `${params.agent.id} prompt execution aborted`,
+        },
+      });
+    const cleanup = () => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      params.abortSignal?.removeEventListener("abort", onAbort);
+      signal.removeEventListener("abort", onAbort);
+      try {
+        child.kill("SIGKILL");
+      } catch (error) {
+        void error;
+      }
+    };
+    const onAbort = () => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      cleanup();
+      resume(Effect.fail(abortError()));
+    };
     child.stdout?.on("data", (chunk: Buffer) => {
       stdout += chunk.toString("utf8");
     });
     child.stderr?.on("data", (chunk: Buffer) => {
       stderr += chunk.toString("utf8");
     });
-    const timer = setTimeout(() => {
+    if (params.abortSignal?.aborted === true || signal.aborted === true) {
+      finished = true;
+      cleanup();
+      resume(Effect.fail(abortError()));
+      return Effect.void;
+    }
+    params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+    signal.addEventListener("abort", onAbort, { once: true });
+    timer = setTimeout(() => {
       if (finished) {
         return;
       }
       finished = true;
-      try {
-        child.kill("SIGKILL");
-      } catch (error) {
-        void error;
-      }
+      cleanup();
       resume(
         Effect.fail(
           new AgentRunTimeoutError({
@@ -427,7 +475,7 @@ function runPromptProcess(params: {
         return;
       }
       finished = true;
-      clearTimeout(timer);
+      cleanup();
       params.state.turnsExecuted += 1;
       const parsed = parseStreamJson(stdout);
       const responseText = parsed.response.length > 0 ? parsed.response : stderr;
@@ -451,7 +499,7 @@ function runPromptProcess(params: {
         return;
       }
       finished = true;
-      clearTimeout(timer);
+      cleanup();
       resume(
         Effect.fail(
           new HarnessExecutionError({
@@ -463,14 +511,7 @@ function runPromptProcess(params: {
         ),
       );
     });
-    return Effect.sync(() => {
-      clearTimeout(timer);
-      try {
-        child.kill("SIGKILL");
-      } catch (error) {
-        void error;
-      }
-    });
+    return Effect.sync(cleanup);
   });
 }
 

--- a/src/runner/runtime.ts
+++ b/src/runner/runtime.ts
@@ -518,11 +518,14 @@ function buildDockerImage(
       }
       const autoTag = `cc-judge-${sanitizeId(plan.scenarioId)}-${sanitizeId(agent.id)}-${Date.now()}`;
       const imageTag = artifact.imageTag ?? autoTag;
+      const dockerfilePath = artifact.dockerfilePath !== undefined
+        ? path.resolve(contextPath, artifact.dockerfilePath)
+        : undefined;
       const args = [
         "build",
         "-t",
         imageTag,
-        ...(artifact.dockerfilePath !== undefined ? ["-f", artifact.dockerfilePath] : []),
+        ...(dockerfilePath !== undefined ? ["-f", dockerfilePath] : []),
         ...(artifact.target !== undefined ? ["--target", artifact.target] : []),
         ...renderBuildArgs(artifact.buildArgs),
         contextPath,

--- a/tests/bundle-codec.test.ts
+++ b/tests/bundle-codec.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect } from "vitest";
+import { Effect } from "effect";
+import { bundleAutoCodec } from "../src/emit/bundle-codec.js";
+import { itEffect, EITHER_LEFT } from "./support/effect.js";
+
+describe("bundleAutoCodec", () => {
+  itEffect("decodes a normalized YAML bundle", function* () {
+    const payload = [
+      "runId: bundle-run-1",
+      "project: cc-judge",
+      "scenarioId: bundle-scenario",
+      "name: bundle",
+      "description: normalized bundle",
+      "requirements:",
+      "  expectedBehavior: judge the bundle",
+      "  validationChecks:",
+      "    - bundle reaches the judge",
+      "agents:",
+      "  - id: agent-1",
+      "    name: Agent One",
+      "outcomes:",
+      "  - agentId: agent-1",
+      "    status: completed",
+      "    endedAt: 2026-04-19T00:01:40.000Z",
+    ].join("\n");
+
+    const bundle = yield* bundleAutoCodec.decode(payload, "mem://bundle.yaml");
+
+    expect(bundle.runId).toBe("bundle-run-1");
+    expect(bundle.project).toBe("cc-judge");
+    expect(bundle.outcomes[0]?.agentId).toBe("agent-1");
+  });
+
+  itEffect("rejects malformed bundles", function* () {
+    const payload = JSON.stringify({
+      runId: "bundle-run-1",
+      project: "cc-judge",
+      scenarioId: "bundle-scenario",
+      name: "bundle",
+      description: "missing outcomes",
+      requirements: {
+        expectedBehavior: "judge the bundle",
+        validationChecks: ["bundle reaches the judge"],
+      },
+      agents: [{ id: "agent-1", name: "Agent One" }],
+    });
+
+    const result = yield* Effect.either(bundleAutoCodec.decode(payload, "mem://broken.json"));
+
+    expect(result._tag).toBe(EITHER_LEFT);
+  });
+});

--- a/tests/bundle-pipeline.test.ts
+++ b/tests/bundle-pipeline.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect } from "vitest";
+import { Effect } from "effect";
+import { scoreBundles } from "../src/app/pipeline.js";
+import type { JudgeBackend } from "../src/judge/index.js";
+import type { JudgeResult } from "../src/core/schema.js";
+import { AgentId, ProjectId, RunId, ScenarioId, type JudgmentBundle } from "../src/core/types.js";
+import { itEffect } from "./support/effect.js";
+
+const stubJudge: JudgeBackend = {
+  name: "bundle-judge",
+  judge() {
+    const result: JudgeResult = {
+      pass: true,
+      reason: "bundle pass",
+      issues: [],
+      overallSeverity: null,
+      retryCount: 0,
+    };
+    return Effect.succeed(result);
+  },
+};
+
+function makeBundle(): JudgmentBundle {
+  return {
+    runId: RunId("bundle-run-1"),
+    project: ProjectId("cc-judge"),
+    scenarioId: ScenarioId("bundle-scenario"),
+    name: "bundle",
+    description: "normalized bundle",
+    requirements: {
+      expectedBehavior: "judge the bundle",
+      validationChecks: ["bundle reaches the judge"],
+    },
+    agents: [{ id: "agent-1", name: "Agent One" }],
+    events: [
+      {
+        type: "message",
+        from: "Agent One",
+        channel: "response",
+        text: "done",
+        ts: 1_744_998_100_000,
+      },
+    ],
+    outcomes: [
+      {
+        agentId: AgentId("agent-1"),
+        status: "completed",
+        endedAt: "2026-04-19T00:01:40.000Z",
+      },
+    ],
+    metadata: {
+      modelName: "bundle-model",
+    },
+  };
+}
+
+describe("scoreBundles", () => {
+  itEffect("scores normalized bundles without a runner", function* () {
+    const resultsDir = mkdtempSync(path.join(os.tmpdir(), "cc-judge-bundle-"));
+    const report = yield* scoreBundles([makeBundle()], {
+      judge: stubJudge,
+      resultsDir,
+    });
+
+    expect(report.summary.total).toBe(1);
+    expect(report.summary.passed).toBe(1);
+    expect(report.runs[0]?.source).toBe("bundle");
+    expect(report.runs[0]?.modelName).toBe("bundle-model");
+  });
+});

--- a/tests/planned-run-failure.test.ts
+++ b/tests/planned-run-failure.test.ts
@@ -1,7 +1,15 @@
 import { mkdtempSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect } from "vitest";
+import { describe, expect, vi } from "vitest";
+
+const { randomUUIDMock } = vi.hoisted(() => ({
+  randomUUIDMock: vi.fn(),
+}));
+
+vi.mock("node:crypto", () => ({
+  randomUUID: randomUUIDMock,
+}));
 import { Effect } from "effect";
 import { runWithHarness } from "../src/app/pipeline.js";
 import { RunCoordinationError } from "../src/core/errors.js";
@@ -126,5 +134,47 @@ describe("runWithHarness failure folding", () => {
     expect(report.runs[0]?.reason).toContain("alpha cancelled");
     expect(report.runs[0]?.reason).toContain("beta cancelled");
     expect(report.runs[0]?.reason).not.toContain("runtime_error");
+  });
+
+  itEffect("uses a unique runId for each deterministic failure bundle", function* () {
+    const judge: JudgeBackend = {
+      name: "should-not-run",
+      judge() {
+        return Effect.die("judge should not run for coordinator failures");
+      },
+    };
+    const coordinator = {
+      execute() {
+        return Effect.fail(
+          new RunCoordinationError({
+            cause: {
+              _tag: "HarnessFailed",
+              detail: {
+                _tag: "ExecutionFailed",
+                message: "aborted",
+              },
+            },
+          }),
+        );
+      },
+    };
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_726_000_000_000);
+    randomUUIDMock.mockReturnValueOnce("run-one").mockReturnValueOnce("run-two");
+    try {
+      yield* runWithHarness(makePlan(), unusedHarness, {
+        coordinator,
+        judge,
+        resultsDir: mkdtempSync(path.join(os.tmpdir(), "cc-judge-fold-runid-1-")),
+      });
+      yield* runWithHarness(makePlan(), unusedHarness, {
+        coordinator,
+        judge,
+        resultsDir: mkdtempSync(path.join(os.tmpdir(), "cc-judge-fold-runid-2-")),
+      });
+      expect(randomUUIDMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      nowSpy.mockRestore();
+      randomUUIDMock.mockReset();
+    }
   });
 });

--- a/tests/planned-run-failure.test.ts
+++ b/tests/planned-run-failure.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect } from "vitest";
+import { Effect } from "effect";
+import { runWithHarness } from "../src/app/pipeline.js";
+import { RunCoordinationError } from "../src/core/errors.js";
+import type { JudgeBackend } from "../src/judge/index.js";
+import {
+  AgentId,
+  ProjectId,
+  ScenarioId,
+  type AgentDeclaration,
+  type RunPlan,
+} from "../src/core/types.js";
+import { itEffect } from "./support/effect.js";
+
+function makePlan(): RunPlan {
+  const agents: readonly [AgentDeclaration, AgentDeclaration] = [
+    {
+      id: AgentId("alpha"),
+      name: "Alpha",
+      artifact: { _tag: "DockerImageArtifact", image: "repo/alpha:latest" },
+      promptInputs: {},
+    },
+    {
+      id: AgentId("beta"),
+      name: "Beta",
+      artifact: { _tag: "DockerImageArtifact", image: "repo/beta:latest" },
+      promptInputs: {},
+    },
+  ];
+  return {
+    project: ProjectId("cc-judge"),
+    scenarioId: ScenarioId("planned-failure"),
+    name: "planned-failure",
+    description: "planned failure path",
+    agents,
+    requirements: {
+      expectedBehavior: "fold failures deterministically",
+      validationChecks: ["no judge call on coordinator failure"],
+    },
+  };
+}
+
+const unusedHarness = {
+  name: "unused",
+  run() {
+    return Effect.void;
+  },
+};
+
+describe("runWithHarness failure folding", () => {
+  itEffect("folds agent-start failure deterministically without invoking the judge", function* () {
+    let judgeCalled = false;
+    const judge: JudgeBackend = {
+      name: "should-not-run",
+      judge() {
+        judgeCalled = true;
+        return Effect.die("judge should not run for coordinator failures");
+      },
+    };
+    const coordinator = {
+      execute() {
+        return Effect.fail(
+          new RunCoordinationError({
+            cause: {
+              _tag: "AgentStartFailed",
+              agentId: "alpha",
+              detail: {
+                _tag: "BuildContextMissing",
+                path: "/tmp/missing-context",
+              },
+            },
+          }),
+        );
+      },
+    };
+
+    const report = yield* runWithHarness(makePlan(), unusedHarness, {
+      coordinator,
+      judge,
+      resultsDir: mkdtempSync(path.join(os.tmpdir(), "cc-judge-fold-start-")),
+    });
+
+    expect(judgeCalled).toBe(false);
+    expect(report.summary.failed).toBe(1);
+    expect(report.runs[0]?.judgeModel).toBe("deterministic/coordinator");
+    expect(report.runs[0]?.reason).toContain("alpha failed_to_start");
+    expect(report.runs[0]?.reason).toContain("beta cancelled");
+  });
+
+  itEffect("preserves cancelled status when the run is aborted", function* () {
+    const abortController = new AbortController();
+    abortController.abort();
+    const judge: JudgeBackend = {
+      name: "should-not-run",
+      judge() {
+        return Effect.die("judge should not run for cancelled coordinator failures");
+      },
+    };
+    const coordinator = {
+      execute() {
+        return Effect.fail(
+          new RunCoordinationError({
+            cause: {
+              _tag: "HarnessFailed",
+              detail: {
+                _tag: "ExecutionFailed",
+                message: "aborted",
+              },
+            },
+          }),
+        );
+      },
+    };
+
+    const report = yield* runWithHarness(makePlan(), unusedHarness, {
+      coordinator,
+      judge,
+      abortSignal: abortController.signal,
+      resultsDir: mkdtempSync(path.join(os.tmpdir(), "cc-judge-fold-cancel-")),
+    });
+
+    expect(report.summary.failed).toBe(1);
+    expect(report.runs[0]?.reason).toContain("alpha cancelled");
+    expect(report.runs[0]?.reason).toContain("beta cancelled");
+    expect(report.runs[0]?.reason).not.toContain("runtime_error");
+  });
+});

--- a/tests/run-coordinator.test.ts
+++ b/tests/run-coordinator.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect } from "vitest";
+import { Effect } from "effect";
+import { DefaultRunCoordinator, PromptWorkspaceHarness, type AgentRuntime, type RuntimeHandle } from "../src/runner/index.js";
+import {
+  AgentId,
+  ProjectId,
+  ScenarioId,
+  type AgentDeclaration,
+  type RunPlan,
+  type Turn,
+  type WorkspaceDiff,
+} from "../src/core/types.js";
+import { itEffect } from "./support/effect.js";
+
+function makePlan(): RunPlan {
+  const agents: readonly [AgentDeclaration, AgentDeclaration] = [
+    {
+      id: AgentId("agent-1"),
+      name: "Agent One",
+      artifact: { _tag: "DockerImageArtifact", image: "repo/agent-one:latest" },
+      promptInputs: {},
+    },
+    {
+      id: AgentId("agent-2"),
+      name: "Agent Two",
+      artifact: { _tag: "DockerImageArtifact", image: "repo/agent-two:latest" },
+      promptInputs: {},
+    },
+  ];
+  return {
+    project: ProjectId("cc-judge"),
+    scenarioId: ScenarioId("multi-agent"),
+    name: "multi-agent",
+    description: "multi-agent prompt harness",
+    agents,
+    requirements: {
+      expectedBehavior: "both agents respond",
+      validationChecks: ["each agent emits one response"],
+    },
+  };
+}
+
+class FakeRuntime implements AgentRuntime {
+  readonly kind = "docker" as const;
+  readonly stopped: string[] = [];
+
+  prepare(agent: AgentDeclaration): Effect.Effect<RuntimeHandle, never, never> {
+    const diff: WorkspaceDiff = {
+      changed: [{ path: `${agent.id}.txt`, before: null, after: agent.name }],
+    };
+    return Effect.succeed({
+      agent,
+      kind: "docker",
+      workspaceDir: `/tmp/${agent.id}`,
+      writeWorkspace() {
+        return Effect.void;
+      },
+      executePrompt(prompt: string): Effect.Effect<Turn, never, never> {
+        const startedAt = agent.id === "agent-1"
+          ? "2026-04-19T00:00:02.000Z"
+          : "2026-04-19T00:00:01.000Z";
+        return Effect.succeed({
+          index: 0,
+          prompt,
+          response: `${agent.name} handled ${prompt}`,
+          startedAt,
+          latencyMs: 10,
+          toolCallCount: 0,
+          inputTokens: 2,
+          outputTokens: 3,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        });
+      },
+      diffWorkspace() {
+        return Effect.succeed(diff);
+      },
+    });
+  }
+
+  stop(handle: RuntimeHandle): Effect.Effect<void, never, never> {
+    return Effect.sync(() => {
+      this.stopped.push(handle.agent.id);
+    });
+  }
+}
+
+describe("DefaultRunCoordinator + PromptWorkspaceHarness", () => {
+  itEffect("coordinates a multi-agent run and emits a normalized bundle", function* () {
+    const runtime = new FakeRuntime();
+    const coordinator = new DefaultRunCoordinator(runtime);
+    const harness = new PromptWorkspaceHarness({
+      prompts: ["solve"],
+      workspace: [{ path: "README.md", content: "seed" }],
+    });
+
+    const bundle = yield* coordinator.execute(makePlan(), harness);
+
+    expect(bundle.agents).toHaveLength(2);
+    expect(bundle.outcomes).toHaveLength(2);
+    expect(bundle.turns).toHaveLength(2);
+    expect(bundle.events).toHaveLength(4);
+    const expectedEventTimestamps = [
+      Date.parse("2026-04-19T00:00:01.000Z"),
+      Date.parse("2026-04-19T00:00:01.000Z") + 10,
+      Date.parse("2026-04-19T00:00:02.000Z"),
+      Date.parse("2026-04-19T00:00:02.000Z") + 10,
+    ];
+    expect(bundle.events?.map((event) => event.ts)).toEqual([
+      ...expectedEventTimestamps,
+    ]);
+    expect(bundle.context).toMatchObject({
+      workspaceDiffByAgent: {
+        "agent-1": { changed: [{ path: "agent-1.txt", before: null, after: "Agent One" }] },
+        "agent-2": { changed: [{ path: "agent-2.txt", before: null, after: "Agent Two" }] },
+      },
+    });
+    expect(runtime.stopped.sort()).toEqual(["agent-1", "agent-2"]);
+  });
+});

--- a/tests/run-coordinator.test.ts
+++ b/tests/run-coordinator.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect } from "vitest";
-import { Effect } from "effect";
+import { describe, expect, vi } from "vitest";
+import { Deferred, Effect, Exit } from "effect";
 import { DefaultRunCoordinator, PromptWorkspaceHarness, type AgentRuntime, type RuntimeHandle } from "../src/runner/index.js";
+import { HarnessExecutionError } from "../src/core/errors.js";
 import {
   AgentId,
   ProjectId,
@@ -37,6 +38,20 @@ function makePlan(): RunPlan {
       expectedBehavior: "both agents respond",
       validationChecks: ["each agent emits one response"],
     },
+  };
+}
+
+function makeSingleAgentPlan(): RunPlan {
+  const [agent] = makePlan().agents;
+  if (agent === undefined) {
+    throw new Error("missing agent fixture");
+  }
+  return {
+    ...makePlan(),
+    agents: [agent],
+    scenarioId: ScenarioId("single-agent"),
+    name: "single-agent",
+    description: "single-agent prompt harness",
   };
 }
 
@@ -85,6 +100,71 @@ class FakeRuntime implements AgentRuntime {
   }
 }
 
+class AbortAwareRuntime implements AgentRuntime {
+  readonly kind = "docker" as const;
+  readonly stopped: string[] = [];
+  seenAbortSignal: AbortSignal | undefined;
+  aborted = false;
+  readonly #promptReady: Deferred.Deferred<void, never>;
+
+  constructor(promptReady: Deferred.Deferred<void, never>) {
+    this.#promptReady = promptReady;
+  }
+
+  get promptReady(): Deferred.Deferred<void, never> {
+    return this.#promptReady;
+  }
+
+  prepare(agent: AgentDeclaration): Effect.Effect<RuntimeHandle, never, never> {
+    const runtime = this;
+    return Effect.succeed({
+      agent,
+      kind: "docker",
+      workspaceDir: `/tmp/${agent.id}`,
+      writeWorkspace() {
+        return Effect.void;
+      },
+      executePrompt(_prompt: string, opts: { readonly timeoutMs: number; readonly abortSignal?: AbortSignal }): Effect.Effect<Turn, HarnessExecutionError, never> {
+        void opts.timeoutMs;
+        return Effect.async((resume) => {
+          runtime.seenAbortSignal = opts.abortSignal;
+          const onAbort = () => {
+            runtime.aborted = true;
+            resume(
+              Effect.fail(
+                new HarnessExecutionError({
+                  cause: {
+                    _tag: "ExecutionFailed",
+                    message: "aborted",
+                  },
+                }),
+              ),
+            );
+          };
+          if (opts.abortSignal?.aborted === true) {
+            onAbort();
+            return Effect.void;
+          }
+          opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
+          Effect.runSync(Deferred.succeed(runtime.#promptReady, undefined));
+          return Effect.sync(() => {
+            opts.abortSignal?.removeEventListener("abort", onAbort);
+          });
+        });
+      },
+      diffWorkspace() {
+        return Effect.succeed({ changed: [] });
+      },
+    });
+  }
+
+  stop(handle: RuntimeHandle): Effect.Effect<void, never, never> {
+    return Effect.sync(() => {
+      this.stopped.push(handle.agent.id);
+    });
+  }
+}
+
 describe("DefaultRunCoordinator + PromptWorkspaceHarness", () => {
   itEffect("coordinates a multi-agent run and emits a normalized bundle", function* () {
     const runtime = new FakeRuntime();
@@ -116,5 +196,45 @@ describe("DefaultRunCoordinator + PromptWorkspaceHarness", () => {
       },
     });
     expect(runtime.stopped.sort()).toEqual(["agent-1", "agent-2"]);
+  });
+
+  itEffect("assigns unique run IDs even when Date.now is constant", function* () {
+    const runtime = new FakeRuntime();
+    const coordinator = new DefaultRunCoordinator(runtime);
+    const harness = new PromptWorkspaceHarness({
+      prompts: ["solve"],
+      workspace: [{ path: "README.md", content: "seed" }],
+    });
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_726_000_000_000);
+    try {
+      const first = yield* coordinator.execute(makePlan(), harness);
+      const second = yield* coordinator.execute(makePlan(), harness);
+      expect(first.runId).not.toBe(second.runId);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  itEffect("forwards abort signals into the live prompt path", function* () {
+    const promptReady = yield* Deferred.make<void>();
+    const runtime = new AbortAwareRuntime(promptReady);
+    const coordinator = new DefaultRunCoordinator(runtime);
+    const harness = new PromptWorkspaceHarness({
+      prompts: ["wait"],
+      workspace: [{ path: "README.md", content: "seed" }],
+    });
+    const abortController = new AbortController();
+    const fiber = yield* Effect.fork(coordinator.execute(makeSingleAgentPlan(), harness, {
+      abortSignal: abortController.signal,
+    }));
+
+    yield* Deferred.await(promptReady);
+    expect(runtime.seenAbortSignal).toBe(abortController.signal);
+    abortController.abort();
+
+    const exit = yield* fiber.await;
+    expect(runtime.seenAbortSignal).toBe(abortController.signal);
+    expect(runtime.aborted).toBe(true);
+    expect(Exit.isFailure(exit)).toBe(true);
   });
 });

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, vi } from "vitest";
+import { Effect } from "effect";
+
+const { childProcessActual } = vi.hoisted(() => {
+  const { createRequire } = require("node:module") as typeof import("node:module");
+  const req = createRequire(import.meta.url);
+  return {
+    childProcessActual: req("node:child_process") as typeof import("node:child_process"),
+  };
+});
+
+vi.mock("node:child_process", () => ({
+  ...childProcessActual,
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+const { DockerRuntime } = await import("../src/runner/index.js");
+const { AgentId, ProjectId, ScenarioId } = await import("../src/core/types.js");
+import * as childProcess from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { itEffect } from "./support/effect.js";
+
+const execSyncMock = vi.mocked(childProcess.execSync);
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("DockerRuntime", () => {
+  itEffect("resolves dockerfilePath relative to contextPath before docker build", function* () {
+    execSyncMock.mockImplementation((command: string) => {
+      if (command.includes("docker create")) {
+        return Buffer.from("runtime-cid\n");
+      }
+      return Buffer.from("");
+    });
+
+    const repoRoot = mkdtempSync(path.join(os.tmpdir(), "cc-judge-runtime-"));
+    const contextPath = path.join(repoRoot, "agents", "alpha");
+    const relativeDockerfilePath = path.join("docker", "Dockerfile");
+    const absoluteDockerfilePath = path.resolve(contextPath, relativeDockerfilePath);
+
+    mkdirSync(path.join(contextPath, "docker"), { recursive: true });
+    writeFileSync(absoluteDockerfilePath, "FROM alpine:3.19\n", "utf8");
+
+    const runtime = new DockerRuntime();
+    const agent = {
+      id: AgentId("docker-agent"),
+      name: "Docker Agent",
+      artifact: {
+        _tag: "DockerBuildArtifact" as const,
+        contextPath,
+        dockerfilePath: relativeDockerfilePath,
+      },
+      promptInputs: {},
+    };
+    const plan = {
+      project: ProjectId("cc-judge"),
+      scenarioId: ScenarioId("dockerfile-relative"),
+      name: "dockerfile-relative",
+      description: "relative dockerfile path",
+      agents: [agent] as const,
+      requirements: {
+        expectedBehavior: "build from the relative dockerfile",
+        validationChecks: ["docker build uses an absolute Dockerfile path"],
+      },
+    };
+
+    const handle = yield* runtime.prepare(agent, plan);
+    yield* runtime.stop(handle);
+
+    const buildCommand = String(execSyncMock.mock.calls[0]?.[0] ?? "");
+    expect(buildCommand).toContain(`-f ${absoluteDockerfilePath}`);
+    expect(buildCommand).not.toMatch(/(^|\s)-f docker\/Dockerfile(\s|$)/u);
+  });
+});


### PR DESCRIPTION
Closes #61
Spec: https://github.com/chughtapan/cc-judge/issues/59#issuecomment-4276825046
Architect plan: https://github.com/chughtapan/cc-judge/issues/60#issuecomment-4276848299

## What changed
Implemented the approved cc-judge core path for multi-agent execution and normalized bundle scoring. The branch adds the shared RunPlan/JudgmentBundle contract, a coordinator above per-agent runtimes, Docker build or image agent declarations, bundle codecs, bundle-aware judging, and tests for multi-agent execution plus bundle intake.

## Traceability
| New artifact | Kind | Spec anchor | Plan anchor |
| --- | --- | --- | --- |
| `src/core/types.ts`, `src/core/schema.ts`, `src/core/errors.ts` | contract | v1 roster of one or more agents; Docker build/image parity; normalized judgment boundary | `src/core/` shared execution and judgment contract |
| `src/runner/runtime.ts`, `src/runner/coordinator.ts` | runtime + coordinator | higher-order multi-agent execution and per-agent lifecycle outcomes | `RunCoordinator` above per-agent runtimes; built-in generic harness boundary |
| `src/emit/bundle-codec.ts`, `src/judge/index.ts` | bundle intake + judge adapter | upstream repos feed judge-ready normalized bundles; no bespoke judge/report code | canonical `JudgmentBundle` boundary validated at intake |
| `src/app/pipeline.ts`, `src/app/opts.ts` | app composition | live run path + bundle scoring path in core repo | `runWithHarness`, `runPlans`, `scoreBundles`, compatibility `scoreTraces` |

## Scope
- New modules: `src/emit/bundle-codec.ts`, `src/runner/runtime.ts`, `src/runner/coordinator.ts`
- New public exports: bundle codecs, runtime/coordinator interfaces, prompt workspace harness, bundle scoring entrypoints
- New deps: none

## Tests
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm build`

## Simplify skips
- none

## Codex diff review
- unavailable in this environment; skipped

## Confidence
HIGH — full test suite, lint, typecheck, and build passed locally.
