### PR TITLE
[impl-staff] wal substrate

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "braintrust": "0.0.180",
     "effect": "3.11.10",
     "glob": "11.0.0",
+    "proper-lockfile": "4.1.2",
     "yaml": "2.6.1",
     "yargs": "17.7.2"
   },
@@ -65,6 +66,7 @@
     "@stryker-mutator/typescript-checker": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@types/node": "22.10.5",
+    "@types/proper-lockfile": "4.1.4",
     "@types/yargs": "17.0.33",
     "@typescript-eslint/eslint-plugin": "8.19.0",
     "@typescript-eslint/parser": "8.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       glob:
         specifier: 11.0.0
         version: 11.0.0
+      proper-lockfile:
+        specifier: 4.1.2
+        version: 4.1.2
       yaml:
         specifier: 2.6.1
         version: 2.6.1
@@ -42,6 +45,9 @@ importers:
       '@types/node':
         specifier: 22.10.5
         version: 22.10.5
+      '@types/proper-lockfile':
+        specifier: 4.1.4
+        version: 4.1.4
       '@types/yargs':
         specifier: 17.0.33
         version: 17.0.33
@@ -1145,6 +1151,12 @@ packages:
 
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
+
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
@@ -3738,6 +3750,12 @@ snapshots:
   '@types/node@22.10.5':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
+  '@types/retry@0.12.5': {}
 
   '@types/ssh2-streams@0.1.13':
     dependencies:

--- a/src/emit/index.ts
+++ b/src/emit/index.ts
@@ -2,3 +2,4 @@ export * from "./bundle-codec.js";
 export * from "./report.js";
 export * from "./observability.js";
 export * from "./trace-adapter.js";
+export * from "./wal.js";

--- a/src/emit/wal.ts
+++ b/src/emit/wal.ts
@@ -1,0 +1,598 @@
+// Write-ahead log substrate for cc-judge runs.
+//
+// Spec: chughtapan/cc-judge#75 (safer:implement-staff).
+// Design: "cc-judge observability substrate" (/office-hours 2026-04-21) —
+//   §"Recommended Approach step 2", §"Multi-agent seq race protection",
+//   §"Recovery sweep rule", §"WAL line schema".
+//
+// Scope this release (spec acceptance, verbatim):
+//   * `openRunLog(runId) -> {append(event), close(outcome)}`.
+//   * One file handle per runId.
+//   * Appends via `fs.appendFileSync` (no fsync per event).
+//   * `fsync` + atomic rename `inflight/<runId>.jsonl ->
+//     runs/<runId>.jsonl` on `close()` only, with `inflight/` and
+//     `runs/` as siblings under `results/`.
+//   * `Effect.acquireRelease` wraps the WAL lifecycle.
+//   * Concurrency via `proper-lockfile` npm.
+//   * Startup recovery sweep: outcome-present vs outcome-absent rule.
+//   * Multi-agent `seq` monotonicity via `Effect.Semaphore`.
+//   * Envelope `{ v, runId, seq, ts, kind, payload }` — internal only
+//     this release (§"WAL line schema"). NOT a public contract.
+//   * Invariant #12: try/catch swallow on the hot path + structured
+//     warning log on WAL failure.
+//
+// Out of scope: wiring the WAL into `NormalizedBundleSink` (that is P1-a
+// #74, "sink unification"). `emitRun` reading from the WAL is #80.
+// `cc-judge inspect` is P0-c #77. This file only ships the substrate
+// module + recovery sweep + its own tests.
+
+import { Effect, Scope } from "effect";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as lockfile from "proper-lockfile";
+import { RunId } from "../core/types.js";
+
+// ---------------------------------------------------------------------------
+// Envelope constants + kinds. The envelope version is bumped only on
+// breaking shape changes; it is NOT a public contract this release.
+// ---------------------------------------------------------------------------
+
+export const WAL_LINE_VERSION = 1;
+
+// WAL line `kind` discriminator. Maps 1:1 to `NormalizedBundleSink`
+// record* methods so the future sink-unification work (#74) can adopt
+// these tags verbatim, plus `outcome` (terminal line written by
+// `close()`) and `orphaned` (marker the recovery sweep appends when an
+// inflight file is reclaimed without a terminal outcome).
+export const WAL_LINE_KIND = {
+  Turn: "turn",
+  Event: "event",
+  Phase: "phase",
+  Context: "context",
+  WorkspaceDiff: "workspace-diff",
+  Outcome: "outcome",
+  Orphaned: "orphaned",
+} as const;
+export type WalLineKind = (typeof WAL_LINE_KIND)[keyof typeof WAL_LINE_KIND];
+
+// Internal telemetry source for structured warnings. Test code keys on
+// this string; callers inspecting logs key on it.
+export const WAL_WARN_SOURCE = "cc-judge:wal";
+
+// `close()` status channel. The WAL records this on the terminal
+// outcome line; it is not read by anything else in this release.
+export const RUN_CLOSE_STATUS = {
+  Completed: "completed",
+  Failed: "failed",
+  Cancelled: "cancelled",
+} as const;
+export type RunCloseStatus = (typeof RUN_CLOSE_STATUS)[keyof typeof RUN_CLOSE_STATUS];
+
+// Recovery-sweep per-file outcomes, used as the return shape so callers
+// and tests can key on concrete tags rather than parse strings.
+export const RECOVERY_OUTCOME = {
+  Completed: "completed",
+  Orphaned: "orphaned",
+  Locked: "locked",
+  Failed: "failed",
+} as const;
+export type RecoveryOutcome = (typeof RECOVERY_OUTCOME)[keyof typeof RECOVERY_OUTCOME];
+
+// ---------------------------------------------------------------------------
+// Public types.
+// ---------------------------------------------------------------------------
+
+// Caller-facing envelope. `seq` + `ts` + `v` are stamped by the handle;
+// the caller supplies `kind` + `payload`.
+export interface WalLineInput {
+  readonly kind: WalLineKind;
+  readonly payload: unknown;
+}
+
+// Full envelope written to the JSONL file.
+export interface WalLine {
+  readonly v: number;
+  readonly runId: string;
+  readonly seq: number;
+  readonly ts: number;
+  readonly kind: WalLineKind;
+  readonly payload: unknown;
+}
+
+// Terminal `close()` descriptor. Recorded as the last line of the WAL
+// under kind="outcome" before fsync + rename.
+export interface RunCloseOutcome {
+  readonly status: RunCloseStatus;
+  readonly reason?: string;
+  readonly details?: Readonly<Record<string, unknown>>;
+}
+
+// Directory layout under `results/`. `inflight/` and `runs/` MUST live
+// on the same filesystem so the close-time rename is atomic.
+export interface WalPaths {
+  readonly resultsDir: string;
+  readonly inflightDir: string;
+  readonly runsDir: string;
+}
+
+// Per-run WAL handle. `openRunLog` returns this via `Effect.acquireRelease`
+// so scope release guarantees `close()` fires exactly once even on
+// interrupt/exception.
+export interface RunLogHandle {
+  readonly runId: string;
+  readonly paths: WalPaths;
+  append(line: WalLineInput): Effect.Effect<void, never, never>;
+  close(outcome: RunCloseOutcome): Effect.Effect<void, never, never>;
+  isClosed(): boolean;
+}
+
+// Per-file result of the startup recovery sweep.
+export interface RecoveredFile {
+  readonly runId: string;
+  readonly outcome: RecoveryOutcome;
+  // Source path (before rename if rename happened).
+  readonly inflightPath: string;
+  // Destination path after rename, or `null` if the file was left in place
+  // (e.g., lock held by a live process).
+  readonly runsPath: string | null;
+}
+
+export interface RecoverySweepResult {
+  readonly scanned: number;
+  readonly recovered: ReadonlyArray<RecoveredFile>;
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers.
+// ---------------------------------------------------------------------------
+
+// Derive the standard `inflight/` and `runs/` sibling layout from a
+// caller-supplied `results/` parent. Callers do not need to construct
+// `WalPaths` themselves.
+export function walPathsFromResultsDir(resultsDir: string): WalPaths {
+  return {
+    resultsDir,
+    inflightDir: path.join(resultsDir, "inflight"),
+    runsDir: path.join(resultsDir, "runs"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Structured warning log (invariant #12). Every WAL-hot-path fs op that
+// throws is routed here so operators can see a WAL silently degraded
+// instead of the eval's primary output going missing.
+// ---------------------------------------------------------------------------
+
+function walWarn(event: string, detail: Readonly<Record<string, unknown>>): void {
+  // Single-line JSON for log-aggregator compatibility. `process.stderr`
+  // not `console.warn` so test harnesses that capture `console.*` don't
+  // drown in expected warnings.
+  try {
+    const line = JSON.stringify({
+      level: "warn",
+      source: WAL_WARN_SOURCE,
+      event,
+      ts: Date.now(),
+      ...detail,
+    });
+    process.stderr.write(`${line}\n`);
+  } catch (err) { void err; /* invariant #12: swallow */ }
+}
+
+// ---------------------------------------------------------------------------
+// Handle internals.
+// ---------------------------------------------------------------------------
+
+interface HandleState {
+  seq: number;
+  closed: boolean;
+  locked: boolean;
+}
+
+function inflightPathFor(paths: WalPaths, runId: string): string {
+  return path.join(paths.inflightDir, `${runId}.jsonl`);
+}
+
+function runsPathFor(paths: WalPaths, runId: string): string {
+  return path.join(paths.runsDir, `${runId}.jsonl`);
+}
+
+function ensureDirsSync(paths: WalPaths): void {
+  // mkdirp both siblings. `recursive: true` so pre-existing dirs are a
+  // no-op. Wrapped by the caller in try/catch.
+  fs.mkdirSync(paths.inflightDir, { recursive: true });
+  fs.mkdirSync(paths.runsDir, { recursive: true });
+}
+
+function writeLineSync(file: string, line: WalLine): void {
+  fs.appendFileSync(file, `${JSON.stringify(line)}\n`);
+}
+
+function fsyncFile(file: string): void {
+  // Open-fsync-close. We do not hold a long-lived fd (the design doc
+  // explicitly says "no fsync per event"); fsync happens once on
+  // `close()` before the atomic rename.
+  const fd = fs.openSync(file, "r+");
+  try {
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `openRunLog` — the acquire side of Effect.acquireRelease.
+// ---------------------------------------------------------------------------
+
+// Open a WAL handle for `runId`. The returned `Effect` is scoped: on
+// scope release the handle's `close()` fires with status="failed" if
+// the caller never called `close()` explicitly. Callers that want the
+// "completed" path explicit should call `handle.close({ status:
+// "completed" })` before the scope exits.
+export function openRunLog(
+  runIdInput: RunId | string,
+  paths: WalPaths,
+): Effect.Effect<RunLogHandle, never, Scope.Scope> {
+  const runId = String(runIdInput);
+
+  return Effect.acquireRelease(
+    Effect.sync(() => {
+      const file = inflightPathFor(paths, runId);
+      const state: HandleState = { seq: 0, closed: false, locked: false };
+
+      // Create inflight dir (and runs dir, so the close-time rename
+      // doesn't fail on first run).
+      try {
+        ensureDirsSync(paths);
+      } catch (err) {
+        walWarn("mkdir.failed", {
+          runId,
+          inflightDir: paths.inflightDir,
+          runsDir: paths.runsDir,
+          error: errorToString(err),
+        });
+      }
+
+      // Pre-create the empty inflight file so proper-lockfile has a
+      // target to lock. lockSync with `realpath: false` because the file
+      // may live on a tmpfs / overlayfs where realpath is lossy.
+      try {
+        fs.writeFileSync(file, "", { flag: "a" });
+      } catch (err) {
+        walWarn("precreate.failed", { runId, file, error: errorToString(err) });
+      }
+
+      try {
+        lockfile.lockSync(file, { realpath: false, retries: 0 });
+        state.locked = true;
+      } catch (err) {
+        // Another process already owns this runId. Per the spec we still
+        // return a handle; the hot-path writes will land in the shared
+        // file with best-effort seq. The recovery-sweep contract keys on
+        // the LOCK being held, not on our in-memory state, so lock
+        // collision here is diagnostic, not fatal.
+        walWarn("lock.failed", { runId, file, error: errorToString(err) });
+      }
+
+      return makeHandle(runId, paths, state);
+    }),
+    (handle) => {
+      // Release-path close: fires if the caller never called close()
+      // explicitly (scope interrupt, exception in `Effect.scoped`).
+      // `close()` itself is idempotent via the `closed` flag, so an
+      // explicit close() followed by scope release is a no-op on the
+      // second call.
+      return handle.close({
+        status: RUN_CLOSE_STATUS.Failed,
+        reason: "scope released without explicit close",
+      });
+    },
+  );
+}
+
+function makeHandle(
+  runId: string,
+  paths: WalPaths,
+  state: HandleState,
+): RunLogHandle {
+  const file = inflightPathFor(paths, runId);
+
+  // Serialize all appends through an Effect.Semaphore so multi-agent
+  // concurrent emissions produce a strictly monotonic `seq` (design
+  // doc §"Multi-agent seq race protection").
+  // `Effect.makeSemaphore(1)` is synchronous-ish (no IO); we build it
+  // once here so every subsequent call reuses the same permit pool.
+  const semaphore = Effect.runSync(Effect.makeSemaphore(1));
+
+  function appendOneLocked(input: WalLineInput): Effect.Effect<void, never, never> {
+    return Effect.sync(() => {
+      if (state.closed) {
+        // Invariant: post-close appends are dropped with a warning.
+        // A caller that races its own close against an emit is
+        // observable through the log — invariant #12 means we still
+        // return void.
+        walWarn("append.after-close", { runId, kind: input.kind });
+        return;
+      }
+      const line: WalLine = {
+        v: WAL_LINE_VERSION,
+        runId,
+        seq: state.seq,
+        ts: Date.now(),
+        kind: input.kind,
+        payload: input.payload,
+      };
+      try {
+        writeLineSync(file, line);
+        state.seq += 1;
+      } catch (err) {
+        walWarn("append.failed", {
+          runId,
+          kind: input.kind,
+          seq: state.seq,
+          error: errorToString(err),
+        });
+      }
+    });
+  }
+
+  return {
+    runId,
+    paths,
+    isClosed: () => state.closed,
+    append(input) {
+      return semaphore.withPermits(1)(appendOneLocked(input));
+    },
+    close(outcome) {
+      // Serialized so any in-flight append finishes first and the
+      // outcome line is guaranteed last.
+      return semaphore.withPermits(1)(Effect.sync(() => {
+        if (state.closed) return;
+        state.closed = true;
+
+        const outcomeLine: WalLine = {
+          v: WAL_LINE_VERSION,
+          runId,
+          seq: state.seq,
+          ts: Date.now(),
+          kind: WAL_LINE_KIND.Outcome,
+          payload: {
+            status: outcome.status,
+            ...(outcome.reason !== undefined ? { reason: outcome.reason } : {}),
+            ...(outcome.details !== undefined ? { details: outcome.details } : {}),
+          },
+        };
+
+        try {
+          writeLineSync(file, outcomeLine);
+          state.seq += 1;
+        } catch (err) {
+          walWarn("outcome.append.failed", {
+            runId,
+            error: errorToString(err),
+          });
+        }
+
+        try {
+          fsyncFile(file);
+        } catch (err) {
+          walWarn("fsync.failed", { runId, file, error: errorToString(err) });
+        }
+
+        // Release the lock BEFORE the rename. proper-lockfile's
+        // `.lock`/`.unlock` sidecars key on the original path; if we
+        // rename first the unlock cannot find its own sidecar.
+        if (state.locked) {
+          try {
+            lockfile.unlockSync(file, { realpath: false });
+            state.locked = false;
+          } catch (err) {
+            walWarn("unlock.failed", { runId, file, error: errorToString(err) });
+          }
+        }
+
+        const dest = runsPathFor(paths, runId);
+        try {
+          fs.renameSync(file, dest);
+        } catch (err) {
+          walWarn("rename.failed", {
+            runId,
+            from: file,
+            to: dest,
+            error: errorToString(err),
+          });
+        }
+      }));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recovery sweep (startup contract, §"Recovery sweep rule").
+//
+// For every `inflight/<runId>.jsonl`:
+//   - If proper-lockfile reports the file's lock is still held by a
+//     live process -> skip entirely.
+//   - Else if the file contains a terminal outcome line (kind="outcome")
+//     -> rename to `runs/<runId>.jsonl` WITHOUT appending a marker (the
+//     run completed cleanly but crashed between outcome-append and
+//     rename).
+//   - Else -> append `{ "kind": "orphaned", ... }` marker, then rename
+//     to `runs/<runId>.jsonl`.
+//
+// All fs ops are wrapped in try/catch per invariant #12; failure of a
+// single file does not abort the sweep.
+// ---------------------------------------------------------------------------
+
+export function recoverySweep(
+  paths: WalPaths,
+): Effect.Effect<RecoverySweepResult, never, never> {
+  return Effect.sync(() => {
+    const recovered: RecoveredFile[] = [];
+    let entries: ReadonlyArray<string>;
+
+    try {
+      // The inflight dir may not exist yet (first-ever run). Treat
+      // ENOENT as a no-op sweep.
+      entries = fs.readdirSync(paths.inflightDir);
+    } catch (err) {
+      if (!isEnoent(err)) {
+        walWarn("sweep.readdir.failed", {
+          inflightDir: paths.inflightDir,
+          error: errorToString(err),
+        });
+      }
+      return { scanned: 0, recovered: [] };
+    }
+
+    let scanned = 0;
+    for (const entry of entries) {
+      if (!entry.endsWith(".jsonl")) continue;
+      scanned += 1;
+
+      const runId = entry.slice(0, -".jsonl".length);
+      const inflightPath = path.join(paths.inflightDir, entry);
+      const result = sweepOneFile(paths, runId, inflightPath);
+      recovered.push(result);
+    }
+
+    return { scanned, recovered };
+  });
+}
+
+function sweepOneFile(
+  paths: WalPaths,
+  runId: string,
+  inflightPath: string,
+): RecoveredFile {
+  // Step 1: lock-held probe. A held lock means some other live process
+  // owns this file; leave it alone.
+  try {
+    const held = lockfile.checkSync(inflightPath, { realpath: false });
+    if (held) {
+      return {
+        runId,
+        outcome: RECOVERY_OUTCOME.Locked,
+        inflightPath,
+        runsPath: null,
+      };
+    }
+  } catch (err) {
+    walWarn("sweep.check.failed", {
+      runId,
+      file: inflightPath,
+      error: errorToString(err),
+    });
+    // Fall through: treat an uncheckable lock as "probably stale" and
+    // proceed to the outcome-scan step. Worst case we append an
+    // orphaned marker onto a file whose owner was briefly unresponsive;
+    // that's preferable to leaving stale inflight files around forever.
+  }
+
+  // Step 2: scan for a terminal outcome line.
+  const hasOutcome = scanFileForOutcome(inflightPath);
+
+  // Step 3: if no outcome, append orphaned marker.
+  if (!hasOutcome) {
+    try {
+      const marker: WalLine = {
+        v: WAL_LINE_VERSION,
+        runId,
+        // seq=-1 so the marker is obvious and doesn't collide with any
+        // real append; inspect (#77) keys on kind, not seq.
+        seq: -1,
+        ts: Date.now(),
+        kind: WAL_LINE_KIND.Orphaned,
+        payload: { reason: "inflight file recovered without outcome" },
+      };
+      writeLineSync(inflightPath, marker);
+    } catch (err) {
+      walWarn("sweep.mark-orphaned.failed", {
+        runId,
+        file: inflightPath,
+        error: errorToString(err),
+      });
+      return {
+        runId,
+        outcome: RECOVERY_OUTCOME.Failed,
+        inflightPath,
+        runsPath: null,
+      };
+    }
+  }
+
+  // Step 4: rename to runs/.
+  const dest = runsPathFor(paths, runId);
+  try {
+    fs.mkdirSync(paths.runsDir, { recursive: true });
+    fs.renameSync(inflightPath, dest);
+  } catch (err) {
+    walWarn("sweep.rename.failed", {
+      runId,
+      from: inflightPath,
+      to: dest,
+      error: errorToString(err),
+    });
+    return {
+      runId,
+      outcome: RECOVERY_OUTCOME.Failed,
+      inflightPath,
+      runsPath: null,
+    };
+  }
+
+  return {
+    runId,
+    outcome: hasOutcome ? RECOVERY_OUTCOME.Completed : RECOVERY_OUTCOME.Orphaned,
+    inflightPath,
+    runsPath: dest,
+  };
+}
+
+// Linear-scan the file for a `kind: "outcome"` line. Used only by the
+// recovery sweep, where the file size is bounded by one run's event
+// count (typically kilobytes-to-megabytes). `readFileSync` is fine.
+function scanFileForOutcome(file: string): boolean {
+  try {
+    const content = fs.readFileSync(file, "utf8");
+    if (content.length === 0) return false;
+    const lines = content.split("\n");
+    for (const raw of lines) {
+      if (raw.length === 0) continue;
+      // Malformed lines are silently skipped (matches
+      // `readRunsJsonl` policy in `src/emit/report.ts`).
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (err) { void err; continue; }
+      if (isOutcomeLine(parsed)) return true;
+    }
+    return false;
+  } catch (err) {
+    walWarn("sweep.scan.failed", { file, error: errorToString(err) });
+    return false;
+  }
+}
+
+function isOutcomeLine(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const kind = (value as { kind?: unknown }).kind;
+  return kind === WAL_LINE_KIND.Outcome;
+}
+
+// ---------------------------------------------------------------------------
+// Error helpers.
+// ---------------------------------------------------------------------------
+
+function errorToString(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try { return String(err); } catch (inner) { void inner; return "<unstringifiable error>"; }
+}
+
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === "ENOENT"
+  );
+}

--- a/tests/wal.test.ts
+++ b/tests/wal.test.ts
@@ -1,0 +1,391 @@
+// Tests for the WAL substrate (`src/emit/wal.ts`), spec
+// chughtapan/cc-judge#75. Each describe-block below maps to a line of
+// the spec's acceptance criteria:
+//
+//   openRunLog/append/close ........... "Happy path" block
+//   Effect.acquireRelease lifecycle ... "acquireRelease" block
+//   Invariant #12 on ENOSPC ........... "Invariant #12" block
+//   Effect.Semaphore seq monotonicity . "Seq monotonicity" block
+//   Recovery sweep rule ............... "Recovery sweep" block
+//   proper-lockfile concurrency ....... "Lockfile" block
+//   WAL line envelope ................. "Envelope" block
+
+import { describe, expect, it, vi } from "vitest";
+import { Effect, Scope } from "effect";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as lockfile from "proper-lockfile";
+import {
+  RECOVERY_OUTCOME,
+  RUN_CLOSE_STATUS,
+  WAL_LINE_KIND,
+  WAL_LINE_VERSION,
+  openRunLog,
+  recoverySweep,
+  walPathsFromResultsDir,
+  type WalLine,
+} from "../src/emit/wal.js";
+import { RunId } from "../src/core/types.js";
+import { itEffect } from "./support/effect.js";
+
+// ── Test fixture helpers ────────────────────────────────────────────────────
+
+function mkTmpResultsDir(tag: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `cc-judge-wal-${tag}-`));
+}
+
+function readJsonl(file: string): ReadonlyArray<WalLine> {
+  const text = fs.readFileSync(file, "utf8");
+  if (text.length === 0) return [];
+  return text
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as WalLine);
+}
+
+const TEST_RUN_ID_HAPPY = RunId("run-happy");
+const TEST_RUN_ID_ACQ = RunId("run-acq-release");
+const TEST_RUN_ID_ENOSPC = RunId("run-enospc");
+const TEST_RUN_ID_SEQ = RunId("run-seq");
+const TEST_RUN_ID_LOCK1 = RunId("run-lock-1");
+const TEST_RUN_ID_SWEEP_CLEAN = RunId("run-sweep-clean");
+const TEST_RUN_ID_SWEEP_ORPHAN = RunId("run-sweep-orphan");
+const TEST_RUN_ID_SWEEP_LOCKED = RunId("run-sweep-locked");
+const TEST_RUN_ID_ENVELOPE = RunId("run-envelope");
+
+const EVENT_COUNT_CONCURRENT = 20;
+
+// ── Happy path: openRunLog/append/close ────────────────────────────────────
+
+describe("WAL happy path (openRunLog/append/close)", () => {
+  itEffect("appends lines to inflight and atomically renames to runs on close", function* () {
+    const resultsDir = mkTmpResultsDir("happy");
+    const paths = walPathsFromResultsDir(resultsDir);
+
+    yield* Effect.scoped(Effect.gen(function* () {
+      const handle = yield* openRunLog(TEST_RUN_ID_HAPPY, paths);
+      yield* handle.append({ kind: WAL_LINE_KIND.Phase, payload: { name: "phase-A" } });
+      yield* handle.append({ kind: WAL_LINE_KIND.Turn, payload: { index: 0 } });
+      yield* handle.close({ status: RUN_CLOSE_STATUS.Completed });
+    }));
+
+    const inflight = path.join(paths.inflightDir, `${TEST_RUN_ID_HAPPY}.jsonl`);
+    const final = path.join(paths.runsDir, `${TEST_RUN_ID_HAPPY}.jsonl`);
+    expect(fs.existsSync(inflight)).toBe(false);
+    expect(fs.existsSync(final)).toBe(true);
+
+    const lines = readJsonl(final);
+    expect(lines.length).toBe(3);
+    expect(lines[0]?.kind).toBe(WAL_LINE_KIND.Phase);
+    expect(lines[1]?.kind).toBe(WAL_LINE_KIND.Turn);
+    expect(lines[2]?.kind).toBe(WAL_LINE_KIND.Outcome);
+    expect((lines[2]?.payload as { status?: string }).status).toBe(RUN_CLOSE_STATUS.Completed);
+  });
+
+  itEffect("creates inflight/ and runs/ as siblings under resultsDir", function* () {
+    const resultsDir = mkTmpResultsDir("siblings");
+    const paths = walPathsFromResultsDir(resultsDir);
+
+    yield* Effect.scoped(Effect.gen(function* () {
+      const handle = yield* openRunLog(RunId("sibling-check"), paths);
+      yield* handle.close({ status: RUN_CLOSE_STATUS.Completed });
+    }));
+
+    expect(fs.existsSync(paths.inflightDir)).toBe(true);
+    expect(fs.existsSync(paths.runsDir)).toBe(true);
+    expect(path.dirname(paths.inflightDir)).toBe(resultsDir);
+    expect(path.dirname(paths.runsDir)).toBe(resultsDir);
+  });
+});
+
+// ── Effect.acquireRelease lifecycle ─────────────────────────────────────────
+
+describe("WAL Effect.acquireRelease lifecycle", () => {
+  itEffect("scope release without explicit close still renames to runs with failed outcome", function* () {
+    const resultsDir = mkTmpResultsDir("acq");
+    const paths = walPathsFromResultsDir(resultsDir);
+
+    yield* Effect.scoped(Effect.gen(function* () {
+      const handle = yield* openRunLog(TEST_RUN_ID_ACQ, paths);
+      yield* handle.append({ kind: WAL_LINE_KIND.Event, payload: { name: "e1" } });
+      // No explicit close — release fires via scope exit.
+    }));
+
+    const final = path.join(paths.runsDir, `${TEST_RUN_ID_ACQ}.jsonl`);
+    expect(fs.existsSync(final)).toBe(true);
+    const lines = readJsonl(final);
+    const outcome = lines.find((l) => l.kind === WAL_LINE_KIND.Outcome);
+    expect(outcome).toBeDefined();
+    expect((outcome?.payload as { status?: string }).status).toBe(RUN_CLOSE_STATUS.Failed);
+  });
+
+  itEffect("double-close is a no-op (idempotent)", function* () {
+    const resultsDir = mkTmpResultsDir("idemp");
+    const paths = walPathsFromResultsDir(resultsDir);
+
+    yield* Effect.scoped(Effect.gen(function* () {
+      const handle = yield* openRunLog(RunId("run-idemp"), paths);
+      yield* handle.close({ status: RUN_CLOSE_STATUS.Completed });
+      // Release path fires a second close — handle state must see it as
+      // a no-op so no duplicate outcome line is written.
+    }));
+
+    const final = path.join(paths.runsDir, "run-idemp.jsonl");
+    const lines = readJsonl(final);
+    const outcomeLines = lines.filter((l) => l.kind === WAL_LINE_KIND.Outcome);
+    expect(outcomeLines.length).toBe(1);
+  });
+});
+
+// ── Invariant #12: errors on the hot path are swallowed ─────────────────────
+
+describe("WAL invariant #12 (errors swallowed on hot path)", () => {
+  itEffect("append after close is silently dropped", function* () {
+    const resultsDir = mkTmpResultsDir("post-close");
+    const paths = walPathsFromResultsDir(resultsDir);
+
+    yield* Effect.scoped(Effect.gen(function* () {
+      const handle = yield* openRunLog(RunId("run-post-close"), paths);
+      yield* handle.append({ kind: WAL_LINE_KIND.Event, payload: { a: 1 } });
+      yield* handle.close({ status: RUN_CLOSE_STATUS.Completed });
+      // Post-close append must not throw.
+      yield* handle.append({ kind: WAL_LINE_KIND.Event, payload: { a: 2 } });
+    }));
+
+    const final = path.join(paths.runsDir, "run-post-close.jsonl");
+    const lines = readJsonl(final);
+    // Two real lines pre-close (event + outcome). No third event line.
+    expect(lines.length).toBe(2);
+  });
+
+  itEffect("fs failures on the hot path are swallowed; run continues", function* () {
+    // Pre-stage a DIRECTORY at the path where the WAL file should live.
+    // `fs.appendFileSync` will throw EISDIR when it tries to open the
+    // path for writing — exercises the same try/catch swallow branch
+    // that a real ENOSPC would hit, without needing to mock a sealed
+    // ESM export.
+    const resultsDir = mkTmpResultsDir("enospc");
+    const paths = walPathsFromResultsDir(resultsDir);
+    fs.mkdirSync(paths.inflightDir, { recursive: true });
+    fs.mkdirSync(path.join(paths.inflightDir, `${TEST_RUN_ID_ENOSPC}.jsonl`));
+
+    const exit = yield* Effect.exit(Effect.scoped(Effect.gen(function* () {
+      const handle = yield* openRunLog(TEST_RUN_ID_ENOSPC, paths);
+      yield* handle.append({ kind: WAL_LINE_KIND.Event, payload: { a: 1 } });
+      yield* handle.append({ kind: WAL_LINE_KIND.Event, payload: { a: 2 } });
+      yield* handle.close({ status: RUN_CLOSE_STATUS.Completed });
+    })));
+    // The Effect MUST succeed (invariant #12): fs failures are warned
+    // and swallowed, never surface as a Cause.
+    expect(exit._tag).toBe("Success");
+    // avoid unused-import warning on vi when the spy path is unused
+    expect(vi).toBeDefined();
+  });
+});
+
+// ── Effect.Semaphore seq monotonicity under concurrent emission ─────────────
+
+describe("WAL seq monotonicity (Effect.Semaphore)", () => {
+  itEffect(
+    "20 concurrent appends produce strictly monotonic seq 0..19",
+    function* () {
+      const resultsDir = mkTmpResultsDir("seq");
+      const paths = walPathsFromResultsDir(resultsDir);
+
+      yield* Effect.scoped(Effect.gen(function* () {
+        const handle = yield* openRunLog(TEST_RUN_ID_SEQ, paths);
+        const indices = Array.from({ length: EVENT_COUNT_CONCURRENT }, (_, i) => i);
+        yield* Effect.forEach(
+          indices,
+          (i) => handle.append({ kind: WAL_LINE_KIND.Event, payload: { i } }),
+          { concurrency: "unbounded" },
+        );
+        yield* handle.close({ status: RUN_CLOSE_STATUS.Completed });
+      }));
+
+      const final = path.join(paths.runsDir, `${TEST_RUN_ID_SEQ}.jsonl`);
+      const lines = readJsonl(final);
+      // EVENT_COUNT_CONCURRENT event lines + 1 outcome.
+      expect(lines.length).toBe(EVENT_COUNT_CONCURRENT + 1);
+      const eventSeqs = lines
+        .filter((l) => l.kind === WAL_LINE_KIND.Event)
+        .map((l) => l.seq)
+        .sort((a, b) => a - b);
+      // Strictly monotonic: 0..19, no duplicates, no gaps.
+      expect(eventSeqs).toEqual(Array.from({ length: EVENT_COUNT_CONCURRENT }, (_, i) => i));
+      // Outcome is last.
+      expect(lines[lines.length - 1]?.kind).toBe(WAL_LINE_KIND.Outcome);
+      expect(lines[lines.length - 1]?.seq).toBe(EVENT_COUNT_CONCURRENT);
+    },
+    20_000,
+  );
+});
+
+// ── proper-lockfile concurrency ─────────────────────────────────────────────
+
+describe("WAL proper-lockfile concurrency", () => {
+  itEffect(
+    "openRunLog acquires a lock that checkSync observes as held; released on close",
+    function* () {
+      const resultsDir = mkTmpResultsDir("lock");
+      const paths = walPathsFromResultsDir(resultsDir);
+      const file = path.join(paths.inflightDir, `${TEST_RUN_ID_LOCK1}.jsonl`);
+
+      let heldDuringRun = false;
+      yield* Effect.scoped(Effect.gen(function* () {
+        yield* openRunLog(TEST_RUN_ID_LOCK1, paths);
+        heldDuringRun = lockfile.checkSync(file, { realpath: false });
+      }));
+
+      expect(heldDuringRun).toBe(true);
+      // After scope exits, the file has been renamed to runs/ so
+      // checkSync on the inflight path would ENOENT. That's fine —
+      // what matters is that the lock was released cleanly before
+      // rename (tested indirectly: if it hadn't, rename would fail
+      // and the inflight file would still exist).
+      expect(fs.existsSync(file)).toBe(false);
+      expect(fs.existsSync(path.join(paths.runsDir, `${TEST_RUN_ID_LOCK1}.jsonl`))).toBe(true);
+    },
+  );
+
+  itEffect("second openRunLog on the same runId after close succeeds", function* () {
+    const resultsDir = mkTmpResultsDir("lock-reuse");
+    const paths = walPathsFromResultsDir(resultsDir);
+    const runId = RunId("reusable");
+
+    yield* Effect.scoped(Effect.gen(function* () {
+      const h1 = yield* openRunLog(runId, paths);
+      yield* h1.close({ status: RUN_CLOSE_STATUS.Completed });
+    }));
+
+    // Re-open: first run's file is in runs/ now, so inflight/ is empty.
+    // A fresh open creates a new inflight file and locks it.
+    yield* Effect.scoped(Effect.gen(function* () {
+      const h2 = yield* openRunLog(runId, paths);
+      yield* h2.append({ kind: WAL_LINE_KIND.Event, payload: { iteration: 2 } });
+      yield* h2.close({ status: RUN_CLOSE_STATUS.Completed });
+    }));
+
+    // Both files landed — the first at runs/<id>.jsonl, the second
+    // would overwrite (rename is atomic-replace). Just verify the final
+    // has the iteration-2 event.
+    const final = path.join(paths.runsDir, `${runId}.jsonl`);
+    const lines = readJsonl(final);
+    const event = lines.find((l) => l.kind === WAL_LINE_KIND.Event);
+    expect((event?.payload as { iteration?: number }).iteration).toBe(2);
+  });
+});
+
+// ── Recovery sweep rule (startup contract) ─────────────────────────────────
+
+describe("WAL recovery sweep", () => {
+  itEffect("clean sweep: outcome-present inflight is renamed WITHOUT orphaned marker", function* () {
+    const resultsDir = mkTmpResultsDir("sweep-clean");
+    const paths = walPathsFromResultsDir(resultsDir);
+    fs.mkdirSync(paths.inflightDir, { recursive: true });
+    const file = path.join(paths.inflightDir, `${TEST_RUN_ID_SWEEP_CLEAN}.jsonl`);
+
+    // Stage an inflight file with a real outcome line (simulates "run
+    // completed cleanly but crashed between outcome-append and rename").
+    fs.writeFileSync(
+      file,
+      `${JSON.stringify({
+        v: WAL_LINE_VERSION, runId: TEST_RUN_ID_SWEEP_CLEAN, seq: 0, ts: 1,
+        kind: WAL_LINE_KIND.Event, payload: {},
+      })}\n${JSON.stringify({
+        v: WAL_LINE_VERSION, runId: TEST_RUN_ID_SWEEP_CLEAN, seq: 1, ts: 2,
+        kind: WAL_LINE_KIND.Outcome, payload: { status: RUN_CLOSE_STATUS.Completed },
+      })}\n`,
+    );
+
+    const result = yield* recoverySweep(paths);
+    expect(result.scanned).toBe(1);
+    expect(result.recovered.length).toBe(1);
+    expect(result.recovered[0]?.outcome).toBe(RECOVERY_OUTCOME.Completed);
+
+    const final = path.join(paths.runsDir, `${TEST_RUN_ID_SWEEP_CLEAN}.jsonl`);
+    const lines = readJsonl(final);
+    expect(lines.some((l) => l.kind === WAL_LINE_KIND.Orphaned)).toBe(false);
+    expect(lines.some((l) => l.kind === WAL_LINE_KIND.Outcome)).toBe(true);
+  });
+
+  itEffect("orphan sweep: outcome-absent inflight gets orphaned marker + rename", function* () {
+    const resultsDir = mkTmpResultsDir("sweep-orphan");
+    const paths = walPathsFromResultsDir(resultsDir);
+    fs.mkdirSync(paths.inflightDir, { recursive: true });
+    const file = path.join(paths.inflightDir, `${TEST_RUN_ID_SWEEP_ORPHAN}.jsonl`);
+
+    // No outcome line — simulates a crash mid-run.
+    fs.writeFileSync(
+      file,
+      `${JSON.stringify({
+        v: WAL_LINE_VERSION, runId: TEST_RUN_ID_SWEEP_ORPHAN, seq: 0, ts: 1,
+        kind: WAL_LINE_KIND.Turn, payload: { index: 0 },
+      })}\n`,
+    );
+
+    const result = yield* recoverySweep(paths);
+    expect(result.recovered[0]?.outcome).toBe(RECOVERY_OUTCOME.Orphaned);
+
+    const final = path.join(paths.runsDir, `${TEST_RUN_ID_SWEEP_ORPHAN}.jsonl`);
+    const lines = readJsonl(final);
+    expect(lines.some((l) => l.kind === WAL_LINE_KIND.Orphaned)).toBe(true);
+    expect(lines.some((l) => l.kind === WAL_LINE_KIND.Outcome)).toBe(false);
+  });
+
+  itEffect("locked sweep: live-lock inflight is SKIPPED (no rename, no marker)", function* () {
+    const resultsDir = mkTmpResultsDir("sweep-locked");
+    const paths = walPathsFromResultsDir(resultsDir);
+    fs.mkdirSync(paths.inflightDir, { recursive: true });
+    const file = path.join(paths.inflightDir, `${TEST_RUN_ID_SWEEP_LOCKED}.jsonl`);
+    fs.writeFileSync(file, "");
+
+    // Hold the lock for the duration of the sweep.
+    const release = lockfile.lockSync(file, { realpath: false, retries: 0 });
+    try {
+      const result = yield* recoverySweep(paths);
+      expect(result.recovered[0]?.outcome).toBe(RECOVERY_OUTCOME.Locked);
+      // Inflight still present; runs/ dir has no file for this runId.
+      expect(fs.existsSync(file)).toBe(true);
+      expect(fs.existsSync(path.join(paths.runsDir, `${TEST_RUN_ID_SWEEP_LOCKED}.jsonl`))).toBe(false);
+    } finally {
+      release();
+    }
+  });
+
+  itEffect("missing inflight dir returns empty sweep result (first run ever)", function* () {
+    const resultsDir = mkTmpResultsDir("sweep-empty");
+    const paths = walPathsFromResultsDir(resultsDir);
+    // Do NOT create inflight dir; mimic a brand-new install.
+    const result = yield* recoverySweep(paths);
+    expect(result.scanned).toBe(0);
+    expect(result.recovered.length).toBe(0);
+  });
+});
+
+// ── WAL line envelope schema ────────────────────────────────────────────────
+
+describe("WAL line envelope", () => {
+  itEffect("every line has v/runId/seq/ts/kind/payload fields", function* () {
+    const resultsDir = mkTmpResultsDir("envelope");
+    const paths = walPathsFromResultsDir(resultsDir);
+
+    yield* Effect.scoped(Effect.gen(function* () {
+      const handle = yield* openRunLog(TEST_RUN_ID_ENVELOPE, paths);
+      yield* handle.append({ kind: WAL_LINE_KIND.Phase, payload: { name: "x" } });
+      yield* handle.close({ status: RUN_CLOSE_STATUS.Completed });
+    }));
+
+    const final = path.join(paths.runsDir, `${TEST_RUN_ID_ENVELOPE}.jsonl`);
+    const lines = readJsonl(final);
+    for (const l of lines) {
+      expect(l.v).toBe(WAL_LINE_VERSION);
+      expect(l.runId).toBe(TEST_RUN_ID_ENVELOPE);
+      expect(typeof l.seq).toBe("number");
+      expect(typeof l.ts).toBe("number");
+      expect(typeof l.kind).toBe("string");
+      expect(l.payload).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
Closes #75

## What changed

Adds `src/emit/wal.ts` — a per-run write-ahead log that persists `NormalizedBundleSink`-shaped events to `results/inflight/<runId>.jsonl` as they occur, then atomically renames to `results/runs/<runId>.jsonl` on close. Intended to be consumed by the sink-unification work (#74) and `cc-judge inspect` (#77); this PR ships only the substrate module plus tests per the spec's explicit non-goals section ("WAL is additive for this release").

## Traceability

| New artifact | Kind | Spec anchor |
|---|---|---|
| `src/emit/wal.ts` | module | #75 acceptance: `src/emit/wal.ts` published with `openRunLog(runId) → {append(event), close(outcome)}` |
| `openRunLog(runId, paths) → Effect<RunLogHandle, never, Scope>` | public fn | #75: `Effect.acquireRelease` wraps WAL lifecycle |
| `RunLogHandle.append({kind, payload})` | method | #75: appends via `fs.appendFileSync`, no fsync per event |
| `RunLogHandle.close({status, reason?, details?})` | method | #75: `fsync` + atomic rename `inflight/<runId>.jsonl → runs/<runId>.jsonl` on `close()` only |
| `walPathsFromResultsDir(resultsDir)` | public fn | #75: `inflight/` and `runs/` siblings under `results/` |
| `recoverySweep(paths)` | public fn | #75: Recovery sweep on startup implements outcome-present vs outcome-absent rule |
| `Effect.makeSemaphore(1)` inside `makeHandle` | impl detail | #75 + design doc § "Multi-agent seq race protection": seq monotonicity via Effect.Semaphore |
| `WAL_LINE_VERSION`, `WAL_LINE_KIND`, `WalLine`, `WalLineInput`, `RunCloseOutcome`, `RunCloseStatus`, `RecoveryOutcome`, `WalPaths`, `RecoveredFile`, `RecoverySweepResult` | public types | #75 envelope `{v, runId, seq, ts, kind, payload}` — internal this release |
| `walWarn()` structured logger | impl detail | #75 invariant #12: try/catch swallow + structured warning log on WAL failure |
| `proper-lockfile@4.1.2` dep | dep | #75: "Concurrency via proper-lockfile npm (new dep)" |
| `@types/proper-lockfile@4.1.4` devDep | dep | types for above |
| `tests/wal.test.ts` (14 cases) | tests | spec's acceptance criteria + design doc Success Criteria 1, 4, 8, 10 |

## Scope

- **New modules:** `src/emit/wal.ts` (single module).
- **New public exports:** ~15 (per-file barrel added to `src/emit/index.ts`).
- **New deps:** 1 runtime (`proper-lockfile`) + 1 dev (`@types/proper-lockfile`).
- **Tier (from safer-diff-scope):** staff — new module, new dep, new internal contract.

## Dependencies

| Name | Version | License | Justification |
|---|---|---|---|
| proper-lockfile | 4.1.2 (exact) | MIT | #75 acceptance: "Concurrency via proper-lockfile npm (new dep)". Chosen over a manual pidfile + `process.kill(pid, 0)` scheme because PID reuse on long-running CI hosts is a correctness hazard (design doc Arch #1). Sync API (`lockSync` / `unlockSync` / `checkSync`) with `realpath: false` so the lock works on tmpfs and overlayfs where realpath is lossy. Actively maintained, ~1M weekly downloads. |
| @types/proper-lockfile | 4.1.4 (exact) | MIT | Type definitions for the runtime dep; dev-only. |

Both pinned to exact versions per staff-tier policy (no `^` / `~`).

## Tests

`tests/wal.test.ts` — 14 test cases across 6 describe-blocks, each block mapping to one line of the spec's acceptance criteria:

- **Happy path** (2 cases): appends reach inflight, atomic rename to runs on close, envelope schema intact; `inflight/` and `runs/` as siblings under `resultsDir`.
- **Effect.acquireRelease** (2 cases): scope release without explicit close produces a failed-status outcome line; double-close is idempotent (single outcome line).
- **Invariant #12** (2 cases): append-after-close silently dropped; pre-staging a directory at the WAL path to simulate EISDIR/ENOSPC on the hot path — the Effect still succeeds.
- **Seq monotonicity** (1 case): 20 concurrent appends via `Effect.forEach({concurrency: "unbounded"})` produce seq `0..19`, strictly monotonic, no duplicates, no gaps.
- **proper-lockfile** (2 cases): `checkSync` observes the lock as held during the run; second `openRunLog` on the same runId after close succeeds.
- **Recovery sweep** (4 cases): outcome-present file renames without orphaned marker; outcome-absent file gets the marker; locked file is skipped entirely (no rename, no marker); missing inflight dir returns empty result (first-ever run).
- **Envelope** (1 case): every line has `v/runId/seq/ts/kind/payload`.

ENOSPC mocking via `vi.spyOn(fs, "appendFileSync")` does not work under ESM — the `fs` module exports are sealed/non-configurable. Switched to pre-staging a directory at the WAL path, which triggers `EISDIR` through the same try/catch swallow branch that a real ENOSPC would. Noted as a limitation in the test comment; the swallow path is the same either way.

## Simplify skips

- Not run in this PR (see § Pre-PR workflow notes). Design doc § "Recommended Approach step 2" fixes the module's internal shape (semaphore + acquireRelease + path helpers + recovery sweep); there is no obvious simplification that does not relitigate a design decision.

## Codex diff review

- Not run in this PR; the branch was put together under concurrent-worktree pressure (another teammate was actively editing pipeline.ts on the junior/87 branch sharing the same worktree — see § Context). Staff tier policy normally requires one. Happy to run it post-open if reviewer wants it as a blocker.

## Context

This PR went up under unusual conditions: the worktree was being shared with another teammate actively revising PR #89 (junior/87 branch). Branch-switching fought with their edits in both directions. After three stash/checkout cycles, the staff/75 branch got the WAL module + tests cleanly; no stream-events or pipeline.ts changes from junior/87 leaked in.

## Verification

On HEAD (`cadac4b`):
- `pnpm typecheck`: clean.
- `pnpm lint`: 0 errors, 197 pre-existing warnings only.
- `pnpm test tests/wal.test.ts`: 14/14 passing.
- `pnpm test`: 616/616 passing (14 new + 602 pre-existing).

## Confidence

MED — the module implements all 10 spec acceptance bullets with tests, typecheck/lint/test all green, no existing tests regressed. Dropping to MED rather than HIGH because (a) I did not run the pre-PR `/simplify` or `/codex` passes under the concurrent-worktree pressure, (b) I did not run `pnpm mutation` to confirm mutation score ≥ 50 (the shared worktree's stryker cache has had independent issues — see PR #89's `25d52c2` commit), and (c) the `tmpfs`/`overlayfs` filesystem-matrix test noted in the design doc (Success Criterion 11) is not in this PR — that needs a CI-job change outside this module's scope and should be a follow-up on its own issue.