### PR TITLE
[impl-senior] cc-judge inspect <runId> CLI over WAL (#77)

### DIFF
--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -1,4 +1,4 @@
-// CLI entrypoints: `cc-judge run` and `cc-judge score`.
+// CLI entrypoints: `cc-judge run`, `cc-judge score`, and `cc-judge inspect`.
 // Built on yargs. Exit codes: 0 all-pass, 1 any-fail, 2 fatal.
 
 import { Effect } from "effect";
@@ -16,6 +16,8 @@ import { getTraceAdapter, type TraceFormat } from "../emit/trace-adapter.js";
 import { glob as doGlob } from "glob";
 import { RunnerResolutionError } from "../core/errors.js";
 import { runScenarios, scoreTraces } from "./pipeline.js";
+import { inspectRun, type InspectErrorCause } from "./inspect.js";
+import { absurd } from "../core/types.js";
 
 export type CliExitCode = 0 | 1 | 2;
 
@@ -264,6 +266,45 @@ export function parseScoreArgs(raw: unknown): ScoreCliArgs {
   };
 }
 
+// ---------------------------------------------------------------------------
+// inspect subcommand — `cc-judge inspect <runId>`.
+// ---------------------------------------------------------------------------
+
+export interface InspectCliArgs {
+  readonly runId: string;
+  readonly results: string;
+}
+
+export function parseInspectArgs(raw: unknown): InspectCliArgs {
+  const r = asObject(raw);
+  return {
+    runId: typeof r["runId"] === "string" ? r["runId"] : "",
+    results: typeof r["results"] === "string" ? r["results"] : "./eval-results",
+  };
+}
+
+export function inspectCommand(args: InspectCliArgs): Effect.Effect<CliExitCode, never, never> {
+  return Effect.gen(function* () {
+    const result = yield* Effect.either(inspectRun(args.runId, args.results));
+    if (result._tag === "Left") {
+      const cause: InspectErrorCause = result.left.cause;
+      switch (cause._tag) {
+        case "RunNotFound":
+          process.stderr.write(`cc-judge: inspect: run not found: ${cause.runId}\n`);
+          return 2 as CliExitCode;
+        case "DuplicateSeq":
+          process.stderr.write(
+            `cc-judge: inspect: duplicate seq ${String(cause.seq)} in run ${cause.runId}\n`,
+          );
+          return 2 as CliExitCode;
+        default:
+          return absurd(cause);
+      }
+    }
+    return 0 as CliExitCode;
+  });
+}
+
 export function main(argv: ReadonlyArray<string>): Effect.Effect<CliExitCode, never, never> {
   return Effect.suspend(() => {
     const parsed = yargs(argv.slice())
@@ -303,6 +344,11 @@ export function main(argv: ReadonlyArray<string>): Effect.Effect<CliExitCode, ne
           .option("emit-braintrust", { type: "boolean", default: false })
           .option("emit-promptfoo", { type: "string" }),
       )
+      .command("inspect <runId>", "Inspect a run's WAL timeline", (y) =>
+        y
+          .positional("runId", { type: "string", demandOption: true })
+          .option("results", { type: "string", default: "./eval-results" }),
+      )
       .demandCommand(1)
       .strict()
       .help()
@@ -314,6 +360,8 @@ export function main(argv: ReadonlyArray<string>): Effect.Effect<CliExitCode, ne
         return runCommand(parseRunArgs(parsed));
       case "score":
         return scoreCommand(parseScoreArgs(parsed));
+      case "inspect":
+        return inspectCommand(parseInspectArgs(parsed));
       default:
         process.stderr.write(`cc-judge: unknown command\n`);
         return Effect.succeed(2 as CliExitCode);

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,3 +1,4 @@
 export * from "./opts.js";
 export * from "./pipeline.js";
 export * from "./cli.js";
+export * from "./inspect.js";

--- a/src/app/inspect.ts
+++ b/src/app/inspect.ts
@@ -1,0 +1,279 @@
+// CLI module for `cc-judge inspect <runId>`.
+// Spec: chughtapan/cc-judge#77 (safer:implement-senior).
+// Design: §"Recommended Approach step 3" — inspect CLI, §"WAL line schema".
+//
+// Acceptance (verbatim from #77):
+//   * reads WAL (inflight or completed), prints timeline of phases, turns,
+//     events, outcome; works mid-run (inflight/ first, runs/ second).
+//   * seq-gap detection → stderr warns 'missing seq N'.
+//   * duplicate seq → Effect fails with InspectError{DuplicateSeq}.
+//   * malformed JSON line → silently skipped (matches report.ts:readRunsJsonl).
+//   * unknown envelope v → stderr warns 'newer cc-judge wrote this'; line skipped.
+//   * empty inflight → stdout 'no events, no outcome'.
+
+import { Data, Effect } from "effect";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  WAL_LINE_KIND,
+  WAL_LINE_VERSION,
+  walPathsFromResultsDir,
+  type WalLine,
+  type WalLineKind,
+  type WalPaths,
+} from "../emit/wal.js";
+
+// ---------------------------------------------------------------------------
+// Typed error channel (PRINCIPLES.md §3: errors are typed, not thrown).
+// ---------------------------------------------------------------------------
+
+export type InspectErrorCause =
+  | { readonly _tag: "RunNotFound"; readonly runId: string }
+  | { readonly _tag: "DuplicateSeq"; readonly seq: number; readonly runId: string };
+
+export class InspectError extends Data.TaggedError("InspectError")<{
+  readonly cause: InspectErrorCause;
+}> {}
+
+// ---------------------------------------------------------------------------
+// WAL file resolution: inflight/ first, runs/ second.
+// ---------------------------------------------------------------------------
+
+function resolveWalFile(
+  runId: string,
+  walPaths: WalPaths,
+): { readonly file: string; readonly source: "inflight" | "completed" } | null {
+  const inflightFile = path.join(walPaths.inflightDir, `${runId}.jsonl`);
+  if (fs.existsSync(inflightFile)) return { file: inflightFile, source: "inflight" };
+  const runsFile = path.join(walPaths.runsDir, `${runId}.jsonl`);
+  if (fs.existsSync(runsFile)) return { file: runsFile, source: "completed" };
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// JSONL parsing — three per-line outcomes:
+//   1. malformed JSON → silent skip (matching report.ts:readRunsJsonl pattern).
+//   2. unknown v → stderr warn + skip.
+//   3. valid v=1 line → collected.
+// ---------------------------------------------------------------------------
+
+interface ParseResult {
+  readonly lines: ReadonlyArray<WalLine>;
+}
+
+function parseWalFile(file: string): ParseResult {
+  let rawContent: string;
+  try {
+    rawContent = fs.readFileSync(file, "utf8");
+  } catch (err) {
+    void err;
+    return { lines: [] };
+  }
+  if (rawContent.length === 0) return { lines: [] };
+
+  const lines: WalLine[] = [];
+  for (const rawLine of rawContent.split("\n")) {
+    const trimmed = rawLine.trim();
+    if (trimmed.length === 0) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      void err;
+      continue;
+    }
+
+    if (typeof parsed !== "object" || parsed === null) continue;
+
+    const v = (parsed as { v?: unknown })["v"];
+
+    if (typeof v !== "number") continue;
+
+    if (v !== WAL_LINE_VERSION) {
+      process.stderr.write(
+        `cc-judge inspect: newer cc-judge wrote this (v=${String(v)}); line skipped\n`,
+      );
+      continue;
+    }
+
+    lines.push(parsed as WalLine);
+  }
+
+  return { lines };
+}
+
+// ---------------------------------------------------------------------------
+// Seq validation.
+// Orphaned marker (seq=-1) is excluded from validation per wal.ts design.
+// ---------------------------------------------------------------------------
+
+interface SeqCheck {
+  readonly gaps: ReadonlyArray<number>;
+  readonly duplicates: ReadonlyArray<number>;
+}
+
+function checkSeqs(lines: ReadonlyArray<WalLine>): SeqCheck {
+  // Orphaned marker uses seq=-1 by WAL spec; excluded from seq counting.
+  const real = lines.filter((l) => l.kind !== WAL_LINE_KIND.Orphaned);
+  if (real.length === 0) return { gaps: [], duplicates: [] };
+
+  const seen = new Map<number, number>();
+  for (const l of real) {
+    seen.set(l.seq, (seen.get(l.seq) ?? 0) + 1);
+  }
+
+  const duplicates: number[] = [];
+  for (const [s, count] of seen) {
+    if (count > 1) duplicates.push(s);
+  }
+  duplicates.sort((a, b) => a - b);
+
+  const seqList = [...seen.keys()].sort((a, b) => a - b);
+  if (seqList.length <= 1) return { gaps: [], duplicates };
+
+  const first = seqList[0] as number;
+  const last = seqList[seqList.length - 1] as number;
+  const gaps: number[] = [];
+  for (let i = first + 1; i < last; i++) {
+    if (!seen.has(i)) gaps.push(i);
+  }
+
+  return { gaps, duplicates };
+}
+
+// ---------------------------------------------------------------------------
+// Timeline rendering (PRINCIPLES.md §4: exhaustive switch on WalLineKind).
+// ---------------------------------------------------------------------------
+
+function summaryForPayload(kind: WalLineKind, payload: unknown): string {
+  // Typed field accessors avoid the record-cast lint rule while keeping the
+  // switch exhaustive (PRINCIPLES.md §4: default: exhaustiveCheck(kind)).
+  type Obj = {
+    name?: unknown;
+    index?: unknown;
+    type?: unknown;
+    status?: unknown;
+    reason?: unknown;
+  };
+  const obj: Obj =
+    typeof payload === "object" && payload !== null ? (payload as Obj) : {};
+
+  switch (kind) {
+    case WAL_LINE_KIND.Phase:
+      return typeof obj.name === "string" ? `name=${obj.name}` : "";
+    case WAL_LINE_KIND.Turn:
+      return typeof obj.index === "number" ? `index=${String(obj.index)}` : "";
+    case WAL_LINE_KIND.Event:
+      return typeof obj.type === "string" ? `type=${obj.type}` : "";
+    case WAL_LINE_KIND.Context:
+      return "";
+    case WAL_LINE_KIND.WorkspaceDiff:
+      return "";
+    case WAL_LINE_KIND.Outcome: {
+      if (typeof obj.status !== "string") return "";
+      const reason =
+        typeof obj.reason === "string" ? ` reason=${obj.reason}` : "";
+      return `status=${obj.status}${reason}`;
+    }
+    case WAL_LINE_KIND.Orphaned:
+      return "(orphaned)";
+    default: {
+      // Compile-time exhaustiveness: TypeScript errors here if a new
+      // WalLineKind is added without a matching case (PRINCIPLES.md §4).
+      const exhaustiveCheck: never = kind;
+      void exhaustiveCheck;
+      return "";
+    }
+  }
+}
+
+function renderTimeline(
+  lines: ReadonlyArray<WalLine>,
+  source: "inflight" | "completed",
+): void {
+  const eventLines = lines.filter(
+    (l) => l.kind !== WAL_LINE_KIND.Outcome && l.kind !== WAL_LINE_KIND.Orphaned,
+  );
+  const outcomeLines = lines.filter((l) => l.kind === WAL_LINE_KIND.Outcome);
+
+  if (eventLines.length === 0 && outcomeLines.length === 0) {
+    process.stdout.write("  no events, no outcome\n");
+    return;
+  }
+
+  const sorted = [...eventLines].sort((a, b) => a.seq - b.seq);
+  const lastLine = sorted[sorted.length - 1];
+  const maxSeq = lastLine !== undefined ? lastLine.seq : 0;
+  const seqWidth = Math.max(String(maxSeq).length, 1);
+
+  const out: string[] = [];
+  for (const l of sorted) {
+    const seqStr = String(l.seq).padStart(seqWidth, " ");
+    const ts = new Date(l.ts).toISOString();
+    const kind = l.kind.padEnd(14, " ");
+    const summary = summaryForPayload(l.kind, l.payload);
+    const tail = summary.length > 0 ? `  ${summary}` : "";
+    out.push(`  ${seqStr}  ${ts}  ${kind}${tail}\n`);
+  }
+
+  const lastOutcome = outcomeLines[outcomeLines.length - 1];
+  if (lastOutcome !== undefined) {
+    type OutcomePayload = { status?: unknown; reason?: unknown };
+    const p: OutcomePayload =
+      typeof lastOutcome.payload === "object" && lastOutcome.payload !== null
+        ? (lastOutcome.payload as OutcomePayload)
+        : {};
+    const status = typeof p.status === "string" ? p.status : "unknown";
+    const reason = typeof p.reason === "string" ? ` (${p.reason})` : "";
+    out.push(`\n  outcome: ${status}${reason}\n`);
+  } else {
+    const msg =
+      source === "inflight" ? "run still in flight" : "no outcome line found";
+    out.push(`\n  outcome: (none — ${msg})\n`);
+  }
+
+  process.stdout.write(out.join(""));
+}
+
+// ---------------------------------------------------------------------------
+// Public entrypoint — exported for SDK use and CLI wiring in cli.ts.
+// ---------------------------------------------------------------------------
+
+export function inspectRun(
+  runId: string,
+  resultsDir: string,
+): Effect.Effect<void, InspectError, never> {
+  return Effect.suspend(() => {
+    const walPaths = walPathsFromResultsDir(path.resolve(resultsDir));
+    const resolved = resolveWalFile(runId, walPaths);
+
+    if (resolved === null) {
+      return Effect.fail(new InspectError({ cause: { _tag: "RunNotFound", runId } }));
+    }
+
+    const { file, source } = resolved;
+    const { lines } = parseWalFile(file);
+    const { gaps, duplicates } = checkSeqs(lines);
+
+    // Duplicate seq aborts: the file cannot be reliably interpreted.
+    const firstDup = duplicates[0];
+    if (firstDup !== undefined) {
+      return Effect.fail(
+        new InspectError({ cause: { _tag: "DuplicateSeq", seq: firstDup, runId } }),
+      );
+    }
+
+    // Gap detection is advisory: warn but continue rendering.
+    for (const missing of gaps) {
+      process.stderr.write(
+        `cc-judge inspect: warning: missing seq ${String(missing)}\n`,
+      );
+    }
+
+    process.stdout.write(`cc-judge inspect: run ${runId} [${source}]\n\n`);
+    renderTimeline(lines, source);
+
+    return Effect.void;
+  });
+}

--- a/tests/inspect.test.ts
+++ b/tests/inspect.test.ts
@@ -1,0 +1,460 @@
+// Tests for `src/app/inspect.ts` — spec chughtapan/cc-judge#77.
+//
+// Each describe-block maps to one acceptance criterion:
+//   seq-gap detection .......... warns 'missing seq 2'
+//   duplicate seq .............. aborts with InspectError{DuplicateSeq}
+//   malformed JSON line ........ skipped silently
+//   unknown envelope v ......... warns 'newer cc-judge wrote this'
+//   empty inflight ............. renders 'no events, no outcome'
+
+import { describe, expect, beforeEach, afterEach } from "vitest";
+import { Effect } from "effect";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { WAL_LINE_KIND, WAL_LINE_VERSION } from "../src/emit/wal.js";
+import { inspectRun, InspectError } from "../src/app/inspect.js";
+import { itEffect } from "./support/effect.js";
+
+// ---------------------------------------------------------------------------
+// I/O capture helpers (mirrors cli.test.ts installStderrCapture pattern).
+// ---------------------------------------------------------------------------
+
+type WriteFn = typeof process.stdout.write;
+type Writable = { write: WriteFn };
+
+interface CaptureHandle {
+  readonly chunks: string[];
+  readonly restore: () => void;
+}
+
+function captureStream(stream: NodeJS.WriteStream): CaptureHandle {
+  const chunks: string[] = [];
+  const original = stream.write.bind(stream);
+  const spy: WriteFn = ((s: string | Uint8Array): boolean => {
+    chunks.push(typeof s === "string" ? s : Buffer.from(s).toString("utf8"));
+    return true;
+  }) as WriteFn;
+  (stream as unknown as Writable).write = spy;
+  const restore = (): void => {
+    (stream as unknown as Writable).write = original;
+  };
+  return { chunks, restore };
+}
+
+// ---------------------------------------------------------------------------
+// WAL line fixture helpers.
+// ---------------------------------------------------------------------------
+
+function mkTmpResultsDir(tag: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `cc-judge-inspect-${tag}-`));
+}
+
+interface WalLineFixture {
+  readonly v: number;
+  readonly runId: string;
+  readonly seq: number;
+  readonly ts: number;
+  readonly kind: string;
+  readonly payload: unknown;
+}
+
+function walLine(
+  runId: string,
+  seq: number,
+  kind: string,
+  payload: unknown = {},
+  v: number = WAL_LINE_VERSION,
+): WalLineFixture {
+  return { v, runId, seq, ts: Date.now(), kind, payload };
+}
+
+function writeInflightFile(
+  inflightDir: string,
+  runId: string,
+  lines: ReadonlyArray<WalLineFixture>,
+): string {
+  fs.mkdirSync(inflightDir, { recursive: true });
+  const file = path.join(inflightDir, `${runId}.jsonl`);
+  const content = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  fs.writeFileSync(file, content, "utf8");
+  return file;
+}
+
+function writeRunsFile(
+  runsDir: string,
+  runId: string,
+  lines: ReadonlyArray<WalLineFixture>,
+): string {
+  fs.mkdirSync(runsDir, { recursive: true });
+  const file = path.join(runsDir, `${runId}.jsonl`);
+  const content = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  fs.writeFileSync(file, content, "utf8");
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+// 1. seq-gap detection: seq 0, 1, 3 → warns 'missing seq 2'.
+// ---------------------------------------------------------------------------
+
+describe("inspect seq-gap detection", () => {
+  let stdoutCapture: CaptureHandle;
+  let stderrCapture: CaptureHandle;
+
+  beforeEach(() => {
+    stdoutCapture = captureStream(process.stdout);
+    stderrCapture = captureStream(process.stderr);
+  });
+
+  afterEach(() => {
+    stdoutCapture.restore();
+    stderrCapture.restore();
+  });
+
+  itEffect("warns 'missing seq 2' when seq jumps from 1 to 3", function* () {
+    const resultsDir = mkTmpResultsDir("gap");
+    const runId = "run-gap-test";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    writeInflightFile(inflightDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "setup" }),
+      walLine(runId, 1, WAL_LINE_KIND.Turn, { index: 0 }),
+      // seq 2 is intentionally missing
+      walLine(runId, 3, WAL_LINE_KIND.Event, { type: "tool_use" }),
+    ]);
+
+    const result = yield* Effect.exit(inspectRun(runId, resultsDir));
+    // Gap detection is advisory — the Effect resolves successfully.
+    expect(result._tag).toBe("Success");
+
+    const stderr = stderrCapture.chunks.join("");
+    expect(stderr).toContain("missing seq 2");
+  });
+
+  itEffect("warns once per missing seq (multiple gaps each emitted)", function* () {
+    const resultsDir = mkTmpResultsDir("gap-multi");
+    const runId = "run-gap-multi";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    writeInflightFile(inflightDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "p" }),
+      // seqs 1 and 2 missing
+      walLine(runId, 3, WAL_LINE_KIND.Turn, { index: 0 }),
+    ]);
+
+    yield* inspectRun(runId, resultsDir);
+
+    const stderr = stderrCapture.chunks.join("");
+    expect(stderr).toContain("missing seq 1");
+    expect(stderr).toContain("missing seq 2");
+  });
+
+  itEffect("no gap warning when seqs are contiguous", function* () {
+    const resultsDir = mkTmpResultsDir("gap-none");
+    const runId = "run-gap-none";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    writeInflightFile(inflightDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "p" }),
+      walLine(runId, 1, WAL_LINE_KIND.Turn, { index: 0 }),
+      walLine(runId, 2, WAL_LINE_KIND.Event, { type: "t" }),
+    ]);
+
+    yield* inspectRun(runId, resultsDir);
+
+    const stderr = stderrCapture.chunks.join("");
+    expect(stderr).not.toContain("missing seq");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. duplicate seq: aborts with InspectError{DuplicateSeq}.
+// ---------------------------------------------------------------------------
+
+describe("inspect duplicate-seq detection", () => {
+  itEffect("fails with InspectError{DuplicateSeq} when seq is repeated", function* () {
+    const resultsDir = mkTmpResultsDir("dup");
+    const runId = "run-dup-test";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    writeInflightFile(inflightDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "p" }),
+      walLine(runId, 1, WAL_LINE_KIND.Turn, { index: 0 }),
+      walLine(runId, 1, WAL_LINE_KIND.Turn, { index: 1 }), // duplicate seq=1
+    ]);
+
+    const result = yield* Effect.exit(inspectRun(runId, resultsDir));
+
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      const err = result.cause;
+      // Effect wraps the error in a Cause; unwrap to get the InspectError.
+      const inspectErr = (err as { _tag?: string; error?: InspectError }).error;
+      expect(inspectErr).toBeInstanceOf(InspectError);
+      if (inspectErr instanceof InspectError) {
+        expect(inspectErr.cause._tag).toBe("DuplicateSeq");
+        if (inspectErr.cause._tag === "DuplicateSeq") {
+          expect(inspectErr.cause.seq).toBe(1);
+          expect(inspectErr.cause.runId).toBe(runId);
+        }
+      }
+    }
+  });
+
+  itEffect("reports the lowest duplicate seq when multiple seqs are repeated", function* () {
+    const resultsDir = mkTmpResultsDir("dup-multi");
+    const runId = "run-dup-multi";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    writeInflightFile(inflightDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, {}),
+      walLine(runId, 0, WAL_LINE_KIND.Phase, {}), // dup at 0
+      walLine(runId, 2, WAL_LINE_KIND.Turn, {}),
+      walLine(runId, 2, WAL_LINE_KIND.Turn, {}), // dup at 2
+    ]);
+
+    const result = yield* Effect.either(inspectRun(runId, resultsDir));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left.cause._tag).toBe("DuplicateSeq");
+      if (result.left.cause._tag === "DuplicateSeq") {
+        // duplicates are sorted ascending; lowest dup is 0.
+        expect(result.left.cause.seq).toBe(0);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. malformed JSON line: skipped silently (Effect resolves, output intact).
+// ---------------------------------------------------------------------------
+
+describe("inspect malformed-JSON line handling", () => {
+  itEffect("skips malformed lines silently and renders valid lines", function* () {
+    const resultsDir = mkTmpResultsDir("malformed");
+    const runId = "run-malformed";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    // Write mix of valid + malformed content manually.
+    fs.mkdirSync(inflightDir, { recursive: true });
+    const file = path.join(inflightDir, `${runId}.jsonl`);
+    const goodLine = JSON.stringify(
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "planning" }),
+    );
+    fs.writeFileSync(
+      file,
+      `${goodLine}\n{not valid json\n{"also": "bad json without closing\n`,
+      "utf8",
+    );
+
+    const stdoutCapture = captureStream(process.stdout);
+    const result = yield* Effect.ensuring(
+      Effect.exit(inspectRun(runId, resultsDir)),
+      Effect.sync(() => { stdoutCapture.restore(); }),
+    );
+
+    expect(result._tag).toBe("Success");
+    const stdout = stdoutCapture.chunks.join("");
+    // The valid phase line must appear in the timeline.
+    expect(stdout).toContain("phase");
+    expect(stdout).toContain("planning");
+  });
+
+  itEffect("handles a file that is entirely malformed JSON (zero valid lines)", function* () {
+    const resultsDir = mkTmpResultsDir("all-malformed");
+    const runId = "run-all-malformed";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    fs.mkdirSync(inflightDir, { recursive: true });
+    const file = path.join(inflightDir, `${runId}.jsonl`);
+    fs.writeFileSync(file, "not json at all\n{broken\n", "utf8");
+
+    const stdoutCapture = captureStream(process.stdout);
+    const result = yield* Effect.ensuring(
+      Effect.exit(inspectRun(runId, resultsDir)),
+      Effect.sync(() => { stdoutCapture.restore(); }),
+    );
+
+    // All lines malformed → zero valid lines → renders 'no events, no outcome'.
+    expect(result._tag).toBe("Success");
+    const stdout = stdoutCapture.chunks.join("");
+    expect(stdout).toContain("no events, no outcome");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. unknown envelope v: warns 'newer cc-judge wrote this'; line skipped.
+// ---------------------------------------------------------------------------
+
+describe("inspect unknown-v handling", () => {
+  itEffect("warns 'newer cc-judge wrote this' for v≠1 lines", function* () {
+    const resultsDir = mkTmpResultsDir("unknown-v");
+    const runId = "run-unknown-v";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    // One v=2 (unknown) line and one v=1 (known) line.
+    writeInflightFile(inflightDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "p" }, 2), // unknown v
+      walLine(runId, 1, WAL_LINE_KIND.Turn, { index: 0 }, WAL_LINE_VERSION), // known v
+    ]);
+
+    const stderrCapture = captureStream(process.stderr);
+    const result = yield* Effect.ensuring(
+      Effect.exit(inspectRun(runId, resultsDir)),
+      Effect.sync(() => { stderrCapture.restore(); }),
+    );
+
+    // The unknown-v line is skipped but the Effect must still resolve.
+    expect(result._tag).toBe("Success");
+
+    const stderr = stderrCapture.chunks.join("");
+    expect(stderr).toContain("newer cc-judge wrote this");
+    // The v= value should appear in the message.
+    expect(stderr).toContain("v=2");
+  });
+
+  itEffect("does not warn when all lines have v=1", function* () {
+    const resultsDir = mkTmpResultsDir("known-v");
+    const runId = "run-known-v";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    writeInflightFile(inflightDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "p" }),
+    ]);
+
+    const stderrCapture = captureStream(process.stderr);
+    yield* Effect.ensuring(
+      inspectRun(runId, resultsDir),
+      Effect.sync(() => { stderrCapture.restore(); }),
+    );
+
+    expect(stderrCapture.chunks.join("")).not.toContain("newer cc-judge");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. empty inflight: renders 'no events, no outcome'.
+// ---------------------------------------------------------------------------
+
+describe("inspect empty-inflight handling", () => {
+  itEffect("renders 'no events, no outcome' for an empty inflight file", function* () {
+    const resultsDir = mkTmpResultsDir("empty");
+    const runId = "run-empty";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    // Stage an empty file in inflight/.
+    fs.mkdirSync(inflightDir, { recursive: true });
+    fs.writeFileSync(path.join(inflightDir, `${runId}.jsonl`), "", "utf8");
+
+    const stdoutCapture = captureStream(process.stdout);
+    const result = yield* Effect.ensuring(
+      Effect.exit(inspectRun(runId, resultsDir)),
+      Effect.sync(() => { stdoutCapture.restore(); }),
+    );
+
+    expect(result._tag).toBe("Success");
+    const stdout = stdoutCapture.chunks.join("");
+    expect(stdout).toContain("no events, no outcome");
+  });
+
+  itEffect("labels the run 'inflight' when file is in inflight/", function* () {
+    const resultsDir = mkTmpResultsDir("label-inflight");
+    const runId = "run-label-inflight";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    fs.mkdirSync(inflightDir, { recursive: true });
+    fs.writeFileSync(path.join(inflightDir, `${runId}.jsonl`), "", "utf8");
+
+    const stdoutCapture = captureStream(process.stdout);
+    yield* Effect.ensuring(
+      inspectRun(runId, resultsDir),
+      Effect.sync(() => { stdoutCapture.restore(); }),
+    );
+
+    expect(stdoutCapture.chunks.join("")).toContain("[inflight]");
+  });
+
+  itEffect("labels the run 'completed' when file is in runs/", function* () {
+    const resultsDir = mkTmpResultsDir("label-completed");
+    const runId = "run-label-completed";
+    const runsDir = path.join(resultsDir, "runs");
+
+    writeRunsFile(runsDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Outcome, { status: "completed" }),
+    ]);
+
+    const stdoutCapture = captureStream(process.stdout);
+    yield* Effect.ensuring(
+      inspectRun(runId, resultsDir),
+      Effect.sync(() => { stdoutCapture.restore(); }),
+    );
+
+    expect(stdoutCapture.chunks.join("")).toContain("[completed]");
+  });
+
+  itEffect("fails with RunNotFound when run does not exist in either location", function* () {
+    const resultsDir = mkTmpResultsDir("not-found");
+    const runId = "run-does-not-exist";
+
+    const result = yield* Effect.either(inspectRun(runId, resultsDir));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left.cause._tag).toBe("RunNotFound");
+      if (result.left.cause._tag === "RunNotFound") {
+        expect(result.left.cause.runId).toBe(runId);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Timeline rendering: outcome line and event lines appear in output.
+// ---------------------------------------------------------------------------
+
+describe("inspect timeline rendering", () => {
+  itEffect("prints the outcome status from a completed run", function* () {
+    const resultsDir = mkTmpResultsDir("render-outcome");
+    const runId = "run-render-outcome";
+    const runsDir = path.join(resultsDir, "runs");
+
+    writeRunsFile(runsDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "run" }),
+      walLine(runId, 1, WAL_LINE_KIND.Turn, { index: 0 }),
+      walLine(runId, 2, WAL_LINE_KIND.Outcome, { status: "completed" }),
+    ]);
+
+    const stdoutCapture = captureStream(process.stdout);
+    yield* Effect.ensuring(
+      inspectRun(runId, resultsDir),
+      Effect.sync(() => { stdoutCapture.restore(); }),
+    );
+
+    const stdout = stdoutCapture.chunks.join("");
+    expect(stdout).toContain("outcome: completed");
+    expect(stdout).toContain("phase");
+    expect(stdout).toContain("name=run");
+    expect(stdout).toContain("turn");
+    expect(stdout).toContain("index=0");
+  });
+
+  itEffect("inflight run with no outcome line shows 'run still in flight'", function* () {
+    const resultsDir = mkTmpResultsDir("render-inflight");
+    const runId = "run-render-inflight";
+    const inflightDir = path.join(resultsDir, "inflight");
+
+    writeInflightFile(inflightDir, runId, [
+      walLine(runId, 0, WAL_LINE_KIND.Phase, { name: "setup" }),
+    ]);
+
+    const stdoutCapture = captureStream(process.stdout);
+    yield* Effect.ensuring(
+      inspectRun(runId, resultsDir),
+      Effect.sync(() => { stdoutCapture.restore(); }),
+    );
+
+    const stdout = stdoutCapture.chunks.join("");
+    expect(stdout).toContain("run still in flight");
+  });
+});


### PR DESCRIPTION
Closes #77

## What

Adds `cc-judge inspect <runId>` subcommand that reads a WAL file (inflight or completed) and prints a seq-sorted timeline of phases, turns, events, and outcome.

## Acceptance criteria

| Criterion | File:line |
|-----------|-----------|
| Reads WAL (inflight/ first, runs/ second), prints timeline | `src/app/inspect.ts:42-51` `src/app/inspect.ts:244-286` |
| seq-gap detection → `stderr` warns `missing seq N` | `src/app/inspect.ts:107-120` `src/app/inspect.ts:270-278` |
| duplicate seq → `Effect.fail(InspectError{DuplicateSeq})` | `src/app/inspect.ts:107-120` `src/app/inspect.ts:262-270` |
| malformed JSON line → silently skipped | `src/app/inspect.ts:79-86` |
| unknown envelope v → warns `newer cc-judge wrote this` | `src/app/inspect.ts:89-95` |
| empty inflight → stdout `no events, no outcome` | `src/app/inspect.ts:167-170` |

## Tests

15 tests in `tests/inspect.test.ts` across 6 describe-blocks covering all acceptance criteria.  All pass; the only failures in the suite are pre-existing `docker-log-capture.test.ts` failures from an untracked junior/87 file not part of this PR.

## Simplify pass

Applied findings from `/simplify`:
- Imported `absurd` from `src/core/types.ts` instead of re-defining it in `cli.ts`
- Eliminated redundant `seqSet` in `checkSeqs`; reuses existing `seen` Map
- Flattened nested `undefined` guard in `checkSeqs` with early return
- Buffered per-line `process.stdout.write` calls into one write per render
- Removed tautological `label` variable; uses `source` directly
- Pruned what-comments; kept non-obvious WHY comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)