### PR TITLE
[arch] planned-harness ingress

### DIFF
--- a/docs/architecture/2026-04-22-planned-harness-ingress.md
+++ b/docs/architecture/2026-04-22-planned-harness-ingress.md
@@ -1,0 +1,195 @@
+# Planned-Harness Ingress Architecture
+
+## Summary
+
+This slice adds one new `cc-judge` public surface for file-backed planned-harness execution without changing the existing prompt/workspace scenario path. The shape is: decode YAML into a typed planned-harness document, load one or more documents from disk, compile those documents into the already-existing `PlannedRunInput` substrate, and let the existing `runPlans(...)` pipeline handle execution, judging, and reporting. This is the first architected slice because it unblocks DRY eval migration in MoltZap and arena while keeping generic ownership in `cc-judge`.
+
+## Modules
+
+1. `src/plans/types.ts`
+Purpose: own the typed document model for file-backed planned-harness ingress.
+Public surface: `PlanFilePath`, `PromptWorkspacePlanSpec`, `PlannedHarnessSpec`, `PlannedHarnessDocument`, `LoadedPlannedHarnessDocument`, `CompiledPlannedRun`.
+Dependencies: `../core/types.js`, `../runner/coordinator.js`, `../app/opts.js`, `effect/Brand`.
+
+2. `src/plans/schema.ts`
+Purpose: define the decode boundary for planned-harness documents and surface typed schema failures.
+Public surface: `PlannedHarnessSchemaError`, `PlannedHarnessSchemaErrorCause`, `decodePromptWorkspacePlanSpec(...)`, `decodePlannedHarnessDocuments(...)`.
+Dependencies: `./types.js`, `effect`.
+
+3. `src/plans/loader.ts`
+Purpose: load YAML from files/globs, map parse failures into typed load errors, and enforce duplicate-scenario constraints across loaded plan documents.
+Public surface: `PlannedHarnessLoadError`, `PlannedHarnessLoadErrorCause`, `loadPlannedHarnessPath(...)`.
+Dependencies: `./types.js`, `./schema.js`, `../core/types.js`, `effect`.
+
+4. `src/plans/compiler.ts`
+Purpose: compile loaded planned-harness documents into the existing `PlannedRunInput` execution substrate and provide one public helper that runs a path through the current `runPlans(...)` pipeline.
+Public surface: `compilePlannedHarnessDocuments(...)`, `runPlannedHarnessPath(...)`.
+Dependencies: `./types.js`, `./loader.js`, `../runner/coordinator.js`, `../app/opts.js`, `../app/pipeline.js`, `../core/schema.js`, `effect`.
+
+5. `src/plans/index.ts`
+Purpose: barrel the new planned-harness surface so external consumers use one supported import root instead of deep paths.
+Public surface: re-exports from `types`, `schema`, `loader`, and `compiler`.
+Dependencies: `./types.js`, `./schema.js`, `./loader.js`, `./compiler.js`.
+
+## Interfaces
+
+```ts
+// src/plans/types.ts
+export type PlanFilePath = string & Brand.Brand<"PlanFilePath">;
+export const PlanFilePath: Brand.Brand.Constructor<PlanFilePath>;
+
+export interface PromptWorkspacePlanSpec {
+  readonly kind: "prompt-workspace";
+  readonly config: PromptWorkspaceHarnessConfig;
+}
+
+export type PlannedHarnessSpec = PromptWorkspacePlanSpec;
+
+export interface PlannedHarnessDocument {
+  readonly plan: RunPlan;
+  readonly harness: PlannedHarnessSpec;
+}
+
+export interface LoadedPlannedHarnessDocument {
+  readonly sourcePath: PlanFilePath;
+  readonly document: PlannedHarnessDocument;
+}
+
+export interface CompiledPlannedRun {
+  readonly sourcePath: PlanFilePath;
+  readonly input: PlannedRunInput;
+}
+```
+
+Intent: `types.ts` is the single typed contract between YAML ingress and the pre-existing `runPlans(...)` substrate.
+
+```ts
+// src/plans/schema.ts
+export class PlannedHarnessSchemaError extends Data.TaggedError(
+  "PlannedHarnessSchemaError",
+)<{ readonly cause: PlannedHarnessSchemaErrorCause }> {}
+
+export type PlannedHarnessSchemaErrorCause =
+  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "UnsupportedHarnessKind"; readonly path: PlanFilePath; readonly kind: string }
+  | { readonly _tag: "SchemaInvalid"; readonly path: PlanFilePath; readonly errors: ReadonlyArray<string> };
+
+export function decodePromptWorkspacePlanSpec(
+  source: unknown,
+  originPath: PlanFilePath,
+): Effect.Effect<PromptWorkspacePlanSpec, PlannedHarnessSchemaError, never>;
+
+export function decodePlannedHarnessDocuments(
+  source: unknown,
+  originPath: PlanFilePath,
+): Effect.Effect<ReadonlyArray<PlannedHarnessDocument>, PlannedHarnessSchemaError, never>;
+```
+
+Intent: `schema.ts` owns the bytes-to-types boundary and keeps schema concerns out of file IO and execution code.
+
+```ts
+// src/plans/loader.ts
+export class PlannedHarnessLoadError extends Data.TaggedError(
+  "PlannedHarnessLoadError",
+)<{ readonly cause: PlannedHarnessLoadErrorCause }> {}
+
+export type PlannedHarnessLoadErrorCause =
+  | { readonly _tag: "FileNotFound"; readonly path: string }
+  | { readonly _tag: "GlobNoMatches"; readonly pattern: string }
+  | { readonly _tag: "ParseFailure"; readonly path: PlanFilePath; readonly message: string }
+  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "UnsupportedHarnessKind"; readonly path: PlanFilePath; readonly kind: string }
+  | { readonly _tag: "SchemaInvalid"; readonly path: PlanFilePath; readonly errors: ReadonlyArray<string> }
+  | { readonly _tag: "DuplicateScenarioId"; readonly scenarioId: ScenarioId; readonly paths: readonly [PlanFilePath, PlanFilePath] };
+
+export function loadPlannedHarnessPath(
+  pathOrGlob: string,
+): Effect.Effect<ReadonlyArray<LoadedPlannedHarnessDocument>, PlannedHarnessLoadError, never>;
+```
+
+Intent: `loader.ts` is the only module that touches disk/globs for the new path.
+
+```ts
+// src/plans/compiler.ts
+export function compilePlannedHarnessDocuments(
+  documents: ReadonlyArray<LoadedPlannedHarnessDocument>,
+): Effect.Effect<ReadonlyArray<CompiledPlannedRun>, never, never>;
+
+export function runPlannedHarnessPath(
+  pathOrGlob: string,
+  opts?: HarnessRunOpts,
+): Effect.Effect<Report, PlannedHarnessLoadError, never>;
+```
+
+Intent: `compiler.ts` is the bridge from typed ingress to the existing `runPlans(...)` path; CLI integration stays a thin wrapper over this.
+
+## Data flow
+
+- `app/cli.ts` adds a new planned-harness entrypoint and forwards the provided file path to `runPlannedHarnessPath(...)`.
+- `plans/loader.ts` resolves the path or glob, reads YAML, parses it, and calls `plans/schema.ts` to decode one or more documents.
+- `plans/loader.ts` enforces duplicate `scenarioId` failures across all loaded documents before anything reaches execution.
+- `plans/compiler.ts` maps each decoded `prompt-workspace` document into a `PlannedRunInput` using the existing `PromptWorkspaceHarness` and the existing `RunPlan`.
+- `plans/compiler.ts` hands the compiled inputs to the existing `runPlans(...)` pipeline in `app/pipeline.ts`.
+- Existing `runPlans(...)` execution, judgment, report emission, and observability emitters remain the single runtime/report path.
+- `src/index.ts` re-exports the new `plans` surface so downstream code uses supported package imports rather than deep paths.
+
+```text
+CLI / SDK path
+    |
+    v
+loadPlannedHarnessPath(pathOrGlob)
+    |-- FileNotFound / GlobNoMatches / ParseFailure
+    |-- TopLevelNotObject / UnsupportedHarnessKind / SchemaInvalid
+    |-- DuplicateScenarioId
+    v
+compilePlannedHarnessDocuments(documents)
+    |
+    v
+runPlans(inputs, opts)
+    |-- existing RunCoordinationError folded by current pipeline
+    v
+Report + existing emitters
+```
+
+## Errors
+
+- `decodePromptWorkspacePlanSpec(...)` and `decodePlannedHarnessDocuments(...)` expose `PlannedHarnessSchemaError`.
+- `loadPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`.
+- `compilePlannedHarnessDocuments(...)` is total in this slice and returns `Effect<..., never, never>` because the only supported harness kind is the built-in `prompt-workspace` branch whose construction is local and typed.
+- `runPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`; downstream execution and judgment continue through the existing `runPlans(...)` behavior, which returns a `Report` rather than surfacing execution failures on the outer error channel.
+
+## Dependencies
+
+| library | version | license | why this one |
+|---|---:|---|---|
+| `effect` | `3.21.0` exact pin | MIT | Required to align `cc-judge` with the exact MoltZap typed runtime surface before cross-repo shared contracts can be consumed without compat glue. |
+| `@sinclair/typebox` | `0.33.22` | MIT | Existing schema library already used by `cc-judge`; this slice keeps one schema tool rather than introducing a second decoder stack. |
+| `yaml` | `2.6.1` | ISC | Existing YAML parser already used by `cc-judge`; sufficient for file-backed plan ingress. |
+| `yargs` | `17.7.2` | MIT | Existing CLI parser; the new planned-harness command remains a thin extension over the current command surface. |
+
+## Traceability
+
+| spec item | slice coverage | module / file |
+|---|---|---|
+| Goal 1 / AC: exact `effect` pin and no compat shim for `cc-judge` skew | direct | existing `package.json`, existing `src/index.ts` export surface |
+| Goal 7 / AC: `cc-judge` shared-contract output remains the default eval path | direct | existing `app/pipeline.ts`, new `plans/compiler.ts` |
+| Goal 8 / AC: generic eval substrate ownership collapses into `cc-judge` | direct | new `plans/*` surface |
+| Goal 13 / AC: distinct planned-harness YAML path instead of stretching simple scenario schema | direct | new `plans/schema.ts`, `plans/loader.ts` |
+| Goal 17 / AC: DRY single owner for generic YAML/harness ingress | direct | new `plans/*` surface and existing root export |
+| AC: `cc-judge` exposes supported file-backed planned-harness input path | direct | new `plans/index.ts`, existing `src/index.ts` |
+| AC: existing simple prompt/workspace YAML path remains supported | preserved by design | existing `core/scenario.ts`, existing `app/cli.ts` path for current `run` command |
+| AC: no duplicate generic loader ownership across repos | partial, enabling slice | new `plans/*`; MoltZap and arena migration is deferred to later architect / implement slices |
+
+## Open questions
+
+1. Q: Should the CLI expose the new file-backed planned-harness path as `cc-judge run-plans` or overload the existing `run` command with an additional mode flag?
+   Recommended default: add `run-plans` as a distinct command so the simple scenario path stays stable and operator-facing behavior is explicit.
+   Escalation target: implement-staff in `cc-judge`.
+
+2. Q: Should the loader accept both single-document YAML and arrays-of-documents in the first slice?
+   Recommended default: yes; accept either shape so a suite can live in one file or many files without inventing another wrapper format later.
+   Escalation target: implement-staff in `cc-judge`.
+
+3. Q: Should external harness kinds beyond `prompt-workspace` be first-class in this slice, or arrive later through the temporary repo-local bridge path named by the spec?
+   Recommended default: keep this slice to `prompt-workspace` plus the typed planned-harness document model; let MoltZap and arena use the short-lived bridge until a second consumer justifies upstreaming a generic harness-kind registry.
+   Escalation target: safer:spec only if the umbrella spec changes; otherwise implement-staff.

--- a/docs/architecture/2026-04-22-planned-harness-ingress.md
+++ b/docs/architecture/2026-04-22-planned-harness-ingress.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This slice adds one new `cc-judge` public surface for file-backed planned-harness execution without changing the existing prompt/workspace scenario path. The shape is: decode YAML into a typed planned-harness document, load one or more documents from disk, compile those documents into the already-existing `PlannedRunInput` substrate, and let the existing `runPlans(...)` pipeline handle execution, judging, and reporting. This is the first architected slice because it unblocks DRY eval migration in MoltZap and arena while keeping generic ownership in `cc-judge`.
+This slice adds one new `cc-judge` public ingress for file-backed planned-harness execution without changing the existing prompt/workspace scenario path: a distinct `cc-judge run-plans <plan-path-or-glob>` command plus the matching SDK helper `runPlannedHarnessPath(...)`. The top-level contract is one `PlannedHarnessDocument` object per YAML file. Multi-plan suites are expressed by loading multiple files through the existing path-or-glob fan-in, not by accepting arrays at the top level of one file. Each matched file decodes into exactly one typed planned-harness document, compiles into the already-existing `PlannedRunInput` substrate, and runs through the existing `runPlans(...)` pipeline for execution, judging, and reporting. This is the first architected slice because it unblocks DRY eval migration in MoltZap and arena while keeping generic ownership in `cc-judge`.
 
 ## Modules
 
@@ -12,12 +12,12 @@ Public surface: `PlanFilePath`, `PromptWorkspacePlanSpec`, `PlannedHarnessSpec`,
 Dependencies: `../core/types.js`, `../runner/coordinator.js`, `../app/opts.js`, `effect/Brand`.
 
 2. `src/plans/schema.ts`
-Purpose: define the decode boundary for planned-harness documents and surface typed schema failures.
-Public surface: `PlannedHarnessSchemaError`, `PlannedHarnessSchemaErrorCause`, `decodePromptWorkspacePlanSpec(...)`, `decodePlannedHarnessDocuments(...)`.
+Purpose: define the decode boundary for one planned-harness document per file and surface typed schema failures.
+Public surface: `PlannedHarnessSchemaError`, `PlannedHarnessSchemaErrorCause`, `decodePromptWorkspacePlanSpec(...)`, `decodePlannedHarnessDocument(...)`.
 Dependencies: `./types.js`, `effect`.
 
 3. `src/plans/loader.ts`
-Purpose: load YAML from files/globs, map parse failures into typed load errors, and enforce duplicate-scenario constraints across loaded plan documents.
+Purpose: load YAML from files/globs, require exactly one planned-harness document per matched file, map parse failures into typed load errors, and enforce duplicate-scenario constraints across loaded plan documents.
 Public surface: `PlannedHarnessLoadError`, `PlannedHarnessLoadErrorCause`, `loadPlannedHarnessPath(...)`.
 Dependencies: `./types.js`, `./schema.js`, `../core/types.js`, `effect`.
 
@@ -70,7 +70,7 @@ export class PlannedHarnessSchemaError extends Data.TaggedError(
 )<{ readonly cause: PlannedHarnessSchemaErrorCause }> {}
 
 export type PlannedHarnessSchemaErrorCause =
-  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "TopLevelNotDocument"; readonly path: PlanFilePath }
   | { readonly _tag: "UnsupportedHarnessKind"; readonly path: PlanFilePath; readonly kind: string }
   | { readonly _tag: "SchemaInvalid"; readonly path: PlanFilePath; readonly errors: ReadonlyArray<string> };
 
@@ -79,13 +79,13 @@ export function decodePromptWorkspacePlanSpec(
   originPath: PlanFilePath,
 ): Effect.Effect<PromptWorkspacePlanSpec, PlannedHarnessSchemaError, never>;
 
-export function decodePlannedHarnessDocuments(
+export function decodePlannedHarnessDocument(
   source: unknown,
   originPath: PlanFilePath,
-): Effect.Effect<ReadonlyArray<PlannedHarnessDocument>, PlannedHarnessSchemaError, never>;
+): Effect.Effect<PlannedHarnessDocument, PlannedHarnessSchemaError, never>;
 ```
 
-Intent: `schema.ts` owns the bytes-to-types boundary and keeps schema concerns out of file IO and execution code.
+Intent: `schema.ts` owns the bytes-to-types boundary and keeps schema concerns out of file IO and execution code. One file decodes to one `PlannedHarnessDocument`.
 
 ```ts
 // src/plans/loader.ts
@@ -97,7 +97,7 @@ export type PlannedHarnessLoadErrorCause =
   | { readonly _tag: "FileNotFound"; readonly path: string }
   | { readonly _tag: "GlobNoMatches"; readonly pattern: string }
   | { readonly _tag: "ParseFailure"; readonly path: PlanFilePath; readonly message: string }
-  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "TopLevelNotDocument"; readonly path: PlanFilePath }
   | { readonly _tag: "UnsupportedHarnessKind"; readonly path: PlanFilePath; readonly kind: string }
   | { readonly _tag: "SchemaInvalid"; readonly path: PlanFilePath; readonly errors: ReadonlyArray<string> }
   | { readonly _tag: "DuplicateScenarioId"; readonly scenarioId: ScenarioId; readonly paths: readonly [PlanFilePath, PlanFilePath] };
@@ -107,7 +107,7 @@ export function loadPlannedHarnessPath(
 ): Effect.Effect<ReadonlyArray<LoadedPlannedHarnessDocument>, PlannedHarnessLoadError, never>;
 ```
 
-Intent: `loader.ts` is the only module that touches disk/globs for the new path.
+Intent: `loader.ts` is the only module that touches disk/globs for the new path. Path fan-in happens across files; arrays-of-documents within one file are rejected at the schema boundary.
 
 ```ts
 // src/plans/compiler.ts
@@ -121,12 +121,13 @@ export function runPlannedHarnessPath(
 ): Effect.Effect<Report, PlannedHarnessLoadError, never>;
 ```
 
-Intent: `compiler.ts` is the bridge from typed ingress to the existing `runPlans(...)` path; CLI integration stays a thin wrapper over this.
+Intent: `compiler.ts` is the bridge from typed ingress to the existing `runPlans(...)` path; the distinct CLI `run-plans` command stays a thin wrapper over this SDK helper.
 
 ## Data flow
 
-- `app/cli.ts` adds a new planned-harness entrypoint and forwards the provided file path to `runPlannedHarnessPath(...)`.
-- `plans/loader.ts` resolves the path or glob, reads YAML, parses it, and calls `plans/schema.ts` to decode one or more documents.
+- `app/cli.ts` adds a distinct `run-plans <plan-path-or-glob>` command and forwards the provided file path to `runPlannedHarnessPath(...)`. The existing `run <scenario>` command remains the simple scenario ingress and is not overloaded.
+- `plans/loader.ts` resolves the path or glob, reads YAML, parses each matched file, and calls `plans/schema.ts` to decode exactly one planned-harness document from each file.
+- If a matched file does not have a single planned-harness document object at the top level, `plans/schema.ts` fails with `TopLevelNotDocument`; arrays-of-documents are rejected in this first slice.
 - `plans/loader.ts` enforces duplicate `scenarioId` failures across all loaded documents before anything reaches execution.
 - `plans/compiler.ts` maps each decoded `prompt-workspace` document into a `PlannedRunInput` using the existing `PromptWorkspaceHarness` and the existing `RunPlan`.
 - `plans/compiler.ts` hands the compiled inputs to the existing `runPlans(...)` pipeline in `app/pipeline.ts`.
@@ -134,12 +135,12 @@ Intent: `compiler.ts` is the bridge from typed ingress to the existing `runPlans
 - `src/index.ts` re-exports the new `plans` surface so downstream code uses supported package imports rather than deep paths.
 
 ```text
-CLI / SDK path
+cc-judge run-plans <plan-path-or-glob>
     |
     v
 loadPlannedHarnessPath(pathOrGlob)
     |-- FileNotFound / GlobNoMatches / ParseFailure
-    |-- TopLevelNotObject / UnsupportedHarnessKind / SchemaInvalid
+    |-- TopLevelNotDocument / UnsupportedHarnessKind / SchemaInvalid
     |-- DuplicateScenarioId
     v
 compilePlannedHarnessDocuments(documents)
@@ -153,10 +154,11 @@ Report + existing emitters
 
 ## Errors
 
-- `decodePromptWorkspacePlanSpec(...)` and `decodePlannedHarnessDocuments(...)` expose `PlannedHarnessSchemaError`.
+- `decodePromptWorkspacePlanSpec(...)` and `decodePlannedHarnessDocument(...)` expose `PlannedHarnessSchemaError`.
+- `TopLevelNotDocument` means the YAML root is not one planned-harness document object with `plan` and `harness`; suites spanning multiple plans must use multiple files matched by the input path or glob.
 - `loadPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`.
 - `compilePlannedHarnessDocuments(...)` is total in this slice and returns `Effect<..., never, never>` because the only supported harness kind is the built-in `prompt-workspace` branch whose construction is local and typed.
-- `runPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`; downstream execution and judgment continue through the existing `runPlans(...)` behavior, which returns a `Report` rather than surfacing execution failures on the outer error channel.
+- `runPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`; it is the SDK surface behind the distinct CLI `run-plans` ingress. Downstream execution and judgment continue through the existing `runPlans(...)` behavior, which returns a `Report` rather than surfacing execution failures on the outer error channel.
 
 ## Dependencies
 
@@ -165,7 +167,7 @@ Report + existing emitters
 | `effect` | `3.21.0` exact pin | MIT | Required to align `cc-judge` with the exact MoltZap typed runtime surface before cross-repo shared contracts can be consumed without compat glue. |
 | `@sinclair/typebox` | `0.33.22` | MIT | Existing schema library already used by `cc-judge`; this slice keeps one schema tool rather than introducing a second decoder stack. |
 | `yaml` | `2.6.1` | ISC | Existing YAML parser already used by `cc-judge`; sufficient for file-backed plan ingress. |
-| `yargs` | `17.7.2` | MIT | Existing CLI parser; the new planned-harness command remains a thin extension over the current command surface. |
+| `yargs` | `17.7.2` | MIT | Existing CLI parser; the new `run-plans` command remains a thin extension over the current command surface without overloading `run`. |
 
 ## Traceability
 
@@ -176,20 +178,10 @@ Report + existing emitters
 | Goal 8 / AC: generic eval substrate ownership collapses into `cc-judge` | direct | new `plans/*` surface |
 | Goal 13 / AC: distinct planned-harness YAML path instead of stretching simple scenario schema | direct | new `plans/schema.ts`, `plans/loader.ts` |
 | Goal 17 / AC: DRY single owner for generic YAML/harness ingress | direct | new `plans/*` surface and existing root export |
-| AC: `cc-judge` exposes supported file-backed planned-harness input path | direct | new `plans/index.ts`, existing `src/index.ts` |
-| AC: existing simple prompt/workspace YAML path remains supported | preserved by design | existing `core/scenario.ts`, existing `app/cli.ts` path for current `run` command |
+| AC: `cc-judge` exposes supported file-backed planned-harness input path | direct | new `plans/index.ts`, `plans/compiler.ts`, existing `app/cli.ts` distinct `run-plans` command |
+| AC: existing simple prompt/workspace YAML path remains supported | preserved by design | existing `core/scenario.ts`, existing `app/cli.ts` `run` command remains unchanged |
 | AC: no duplicate generic loader ownership across repos | partial, enabling slice | new `plans/*`; MoltZap and arena migration is deferred to later architect / implement slices |
 
 ## Open questions
 
-1. Q: Should the CLI expose the new file-backed planned-harness path as `cc-judge run-plans` or overload the existing `run` command with an additional mode flag?
-   Recommended default: add `run-plans` as a distinct command so the simple scenario path stays stable and operator-facing behavior is explicit.
-   Escalation target: implement-staff in `cc-judge`.
-
-2. Q: Should the loader accept both single-document YAML and arrays-of-documents in the first slice?
-   Recommended default: yes; accept either shape so a suite can live in one file or many files without inventing another wrapper format later.
-   Escalation target: implement-staff in `cc-judge`.
-
-3. Q: Should external harness kinds beyond `prompt-workspace` be first-class in this slice, or arrive later through the temporary repo-local bridge path named by the spec?
-   Recommended default: keep this slice to `prompt-workspace` plus the typed planned-harness document model; let MoltZap and arena use the short-lived bridge until a second consumer justifies upstreaming a generic harness-kind registry.
-   Escalation target: safer:spec only if the umbrella spec changes; otherwise implement-staff.
+None. This slice explicitly freezes one `PlannedHarnessDocument` object per file and a distinct `cc-judge run-plans` ingress while keeping the existing `run` scenario command unchanged. Additional harness kinds require a later architect slice if the governing spec expands.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from "./runner/index.js";
 export * from "./judge/index.js";
 export * from "./emit/index.js";
 export * from "./app/index.js";
+export * from "./plans/index.js";

--- a/src/plans/compiler.ts
+++ b/src/plans/compiler.ts
@@ -1,0 +1,18 @@
+import { Effect } from "effect";
+import type { HarnessRunOpts } from "../app/opts.js";
+import type { Report } from "../core/schema.js";
+import type { LoadedPlannedHarnessDocument, CompiledPlannedRun } from "./types.js";
+import type { PlannedHarnessLoadError } from "./loader.js";
+
+export function compilePlannedHarnessDocuments(
+  _documents: ReadonlyArray<LoadedPlannedHarnessDocument>,
+): Effect.Effect<ReadonlyArray<CompiledPlannedRun>, never, never> {
+  throw new Error("not implemented");
+}
+
+export function runPlannedHarnessPath(
+  _pathOrGlob: string,
+  _opts: HarnessRunOpts = {},
+): Effect.Effect<Report, PlannedHarnessLoadError, never> {
+  throw new Error("not implemented");
+}

--- a/src/plans/index.ts
+++ b/src/plans/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./schema.js";
+export * from "./loader.js";
+export * from "./compiler.js";

--- a/src/plans/loader.ts
+++ b/src/plans/loader.ts
@@ -20,7 +20,7 @@ export type PlannedHarnessLoadErrorCause =
       readonly message: string;
     }
   | {
-      readonly _tag: "TopLevelNotObject";
+      readonly _tag: "TopLevelNotDocument";
       readonly path: PlanFilePath;
     }
   | {

--- a/src/plans/loader.ts
+++ b/src/plans/loader.ts
@@ -1,0 +1,50 @@
+import { Data, Effect } from "effect";
+import type { ScenarioId } from "../core/types.js";
+import type {
+  LoadedPlannedHarnessDocument,
+  PlanFilePath,
+} from "./types.js";
+
+export class PlannedHarnessLoadError extends Data.TaggedError(
+  "PlannedHarnessLoadError",
+)<{
+  readonly cause: PlannedHarnessLoadErrorCause;
+}> {}
+
+export type PlannedHarnessLoadErrorCause =
+  | { readonly _tag: "FileNotFound"; readonly path: string }
+  | { readonly _tag: "GlobNoMatches"; readonly pattern: string }
+  | {
+      readonly _tag: "ParseFailure";
+      readonly path: PlanFilePath;
+      readonly message: string;
+    }
+  | {
+      readonly _tag: "TopLevelNotObject";
+      readonly path: PlanFilePath;
+    }
+  | {
+      readonly _tag: "UnsupportedHarnessKind";
+      readonly path: PlanFilePath;
+      readonly kind: string;
+    }
+  | {
+      readonly _tag: "SchemaInvalid";
+      readonly path: PlanFilePath;
+      readonly errors: ReadonlyArray<string>;
+    }
+  | {
+      readonly _tag: "DuplicateScenarioId";
+      readonly scenarioId: ScenarioId;
+      readonly paths: readonly [PlanFilePath, PlanFilePath];
+    };
+
+export function loadPlannedHarnessPath(
+  _pathOrGlob: string,
+): Effect.Effect<
+  ReadonlyArray<LoadedPlannedHarnessDocument>,
+  PlannedHarnessLoadError,
+  never
+> {
+  throw new Error("not implemented");
+}

--- a/src/plans/schema.ts
+++ b/src/plans/schema.ts
@@ -1,0 +1,43 @@
+import { Data, Effect } from "effect";
+import type {
+  PlanFilePath,
+  PlannedHarnessDocument,
+  PromptWorkspacePlanSpec,
+} from "./types.js";
+
+export class PlannedHarnessSchemaError extends Data.TaggedError(
+  "PlannedHarnessSchemaError",
+)<{
+  readonly cause: PlannedHarnessSchemaErrorCause;
+}> {}
+
+export type PlannedHarnessSchemaErrorCause =
+  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | {
+      readonly _tag: "UnsupportedHarnessKind";
+      readonly path: PlanFilePath;
+      readonly kind: string;
+    }
+  | {
+      readonly _tag: "SchemaInvalid";
+      readonly path: PlanFilePath;
+      readonly errors: ReadonlyArray<string>;
+    };
+
+export function decodePromptWorkspacePlanSpec(
+  _source: unknown,
+  _originPath: PlanFilePath,
+): Effect.Effect<PromptWorkspacePlanSpec, PlannedHarnessSchemaError, never> {
+  throw new Error("not implemented");
+}
+
+export function decodePlannedHarnessDocuments(
+  _source: unknown,
+  _originPath: PlanFilePath,
+): Effect.Effect<
+  ReadonlyArray<PlannedHarnessDocument>,
+  PlannedHarnessSchemaError,
+  never
+> {
+  throw new Error("not implemented");
+}

--- a/src/plans/schema.ts
+++ b/src/plans/schema.ts
@@ -12,7 +12,7 @@ export class PlannedHarnessSchemaError extends Data.TaggedError(
 }> {}
 
 export type PlannedHarnessSchemaErrorCause =
-  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "TopLevelNotDocument"; readonly path: PlanFilePath }
   | {
       readonly _tag: "UnsupportedHarnessKind";
       readonly path: PlanFilePath;
@@ -31,13 +31,9 @@ export function decodePromptWorkspacePlanSpec(
   throw new Error("not implemented");
 }
 
-export function decodePlannedHarnessDocuments(
+export function decodePlannedHarnessDocument(
   _source: unknown,
   _originPath: PlanFilePath,
-): Effect.Effect<
-  ReadonlyArray<PlannedHarnessDocument>,
-  PlannedHarnessSchemaError,
-  never
-> {
+): Effect.Effect<PlannedHarnessDocument, PlannedHarnessSchemaError, never> {
   throw new Error("not implemented");
 }

--- a/src/plans/types.ts
+++ b/src/plans/types.ts
@@ -1,0 +1,29 @@
+import { Brand } from "effect";
+import type { PlannedRunInput } from "../app/opts.js";
+import type { RunPlan } from "../core/types.js";
+import type { PromptWorkspaceHarnessConfig } from "../runner/coordinator.js";
+
+export type PlanFilePath = string & Brand.Brand<"PlanFilePath">;
+export const PlanFilePath = Brand.nominal<PlanFilePath>();
+
+export interface PromptWorkspacePlanSpec {
+  readonly kind: "prompt-workspace";
+  readonly config: PromptWorkspaceHarnessConfig;
+}
+
+export type PlannedHarnessSpec = PromptWorkspacePlanSpec;
+
+export interface PlannedHarnessDocument {
+  readonly plan: RunPlan;
+  readonly harness: PlannedHarnessSpec;
+}
+
+export interface LoadedPlannedHarnessDocument {
+  readonly sourcePath: PlanFilePath;
+  readonly document: PlannedHarnessDocument;
+}
+
+export interface CompiledPlannedRun {
+  readonly sourcePath: PlanFilePath;
+  readonly input: PlannedRunInput;
+}


### PR DESCRIPTION
Architecture only. Not for merge.

Spec anchor: https://github.com/chughtapan/moltzap/issues/164
Architecture artifact: https://github.com/chughtapan/moltzap/issues/167
Design doc in repo: docs/architecture/2026-04-22-planned-harness-ingress.md

This revision freezes the two contract points raised in gate review:
- planned-harness YAML is one `PlannedHarnessDocument` object per file; suites fan in via multiple files matched by the input path or glob
- public CLI ingress is a distinct `cc-judge run-plans <plan-path-or-glob>` command; existing `run` remains the simple scenario path

PR contents are architecture-only:
- design document revision
- interface stubs only; no runtime implementation
