### PR TITLE
[impl-staff] planned-harness ingress + exact effect alignment

### DIFF
--- a/docs/architecture/2026-04-22-planned-harness-ingress.md
+++ b/docs/architecture/2026-04-22-planned-harness-ingress.md
@@ -1,0 +1,195 @@
+# Planned-Harness Ingress Architecture
+
+## Summary
+
+This slice adds one new `cc-judge` public surface for file-backed planned-harness execution without changing the existing prompt/workspace scenario path. The shape is: decode YAML into a typed planned-harness document, load one or more documents from disk, compile those documents into the already-existing `PlannedRunInput` substrate, and let the existing `runPlans(...)` pipeline handle execution, judging, and reporting. This is the first architected slice because it unblocks DRY eval migration in MoltZap and arena while keeping generic ownership in `cc-judge`.
+
+## Modules
+
+1. `src/plans/types.ts`
+Purpose: own the typed document model for file-backed planned-harness ingress.
+Public surface: `PlanFilePath`, `PromptWorkspacePlanSpec`, `PlannedHarnessSpec`, `PlannedHarnessDocument`, `LoadedPlannedHarnessDocument`, `CompiledPlannedRun`.
+Dependencies: `../core/types.js`, `../runner/coordinator.js`, `../app/opts.js`, `effect/Brand`.
+
+2. `src/plans/schema.ts`
+Purpose: define the decode boundary for planned-harness documents and surface typed schema failures.
+Public surface: `PlannedHarnessSchemaError`, `PlannedHarnessSchemaErrorCause`, `decodePromptWorkspacePlanSpec(...)`, `decodePlannedHarnessDocuments(...)`.
+Dependencies: `./types.js`, `effect`.
+
+3. `src/plans/loader.ts`
+Purpose: load YAML from files/globs, map parse failures into typed load errors, and enforce duplicate-scenario constraints across loaded plan documents.
+Public surface: `PlannedHarnessLoadError`, `PlannedHarnessLoadErrorCause`, `loadPlannedHarnessPath(...)`.
+Dependencies: `./types.js`, `./schema.js`, `../core/types.js`, `effect`.
+
+4. `src/plans/compiler.ts`
+Purpose: compile loaded planned-harness documents into the existing `PlannedRunInput` execution substrate and provide one public helper that runs a path through the current `runPlans(...)` pipeline.
+Public surface: `compilePlannedHarnessDocuments(...)`, `runPlannedHarnessPath(...)`.
+Dependencies: `./types.js`, `./loader.js`, `../runner/coordinator.js`, `../app/opts.js`, `../app/pipeline.js`, `../core/schema.js`, `effect`.
+
+5. `src/plans/index.ts`
+Purpose: barrel the new planned-harness surface so external consumers use one supported import root instead of deep paths.
+Public surface: re-exports from `types`, `schema`, `loader`, and `compiler`.
+Dependencies: `./types.js`, `./schema.js`, `./loader.js`, `./compiler.js`.
+
+## Interfaces
+
+```ts
+// src/plans/types.ts
+export type PlanFilePath = string & Brand.Brand<"PlanFilePath">;
+export const PlanFilePath: Brand.Brand.Constructor<PlanFilePath>;
+
+export interface PromptWorkspacePlanSpec {
+  readonly kind: "prompt-workspace";
+  readonly config: PromptWorkspaceHarnessConfig;
+}
+
+export type PlannedHarnessSpec = PromptWorkspacePlanSpec;
+
+export interface PlannedHarnessDocument {
+  readonly plan: RunPlan;
+  readonly harness: PlannedHarnessSpec;
+}
+
+export interface LoadedPlannedHarnessDocument {
+  readonly sourcePath: PlanFilePath;
+  readonly document: PlannedHarnessDocument;
+}
+
+export interface CompiledPlannedRun {
+  readonly sourcePath: PlanFilePath;
+  readonly input: PlannedRunInput;
+}
+```
+
+Intent: `types.ts` is the single typed contract between YAML ingress and the pre-existing `runPlans(...)` substrate.
+
+```ts
+// src/plans/schema.ts
+export class PlannedHarnessSchemaError extends Data.TaggedError(
+  "PlannedHarnessSchemaError",
+)<{ readonly cause: PlannedHarnessSchemaErrorCause }> {}
+
+export type PlannedHarnessSchemaErrorCause =
+  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "UnsupportedHarnessKind"; readonly path: PlanFilePath; readonly kind: string }
+  | { readonly _tag: "SchemaInvalid"; readonly path: PlanFilePath; readonly errors: ReadonlyArray<string> };
+
+export function decodePromptWorkspacePlanSpec(
+  source: unknown,
+  originPath: PlanFilePath,
+): Effect.Effect<PromptWorkspacePlanSpec, PlannedHarnessSchemaError, never>;
+
+export function decodePlannedHarnessDocuments(
+  source: unknown,
+  originPath: PlanFilePath,
+): Effect.Effect<ReadonlyArray<PlannedHarnessDocument>, PlannedHarnessSchemaError, never>;
+```
+
+Intent: `schema.ts` owns the bytes-to-types boundary and keeps schema concerns out of file IO and execution code.
+
+```ts
+// src/plans/loader.ts
+export class PlannedHarnessLoadError extends Data.TaggedError(
+  "PlannedHarnessLoadError",
+)<{ readonly cause: PlannedHarnessLoadErrorCause }> {}
+
+export type PlannedHarnessLoadErrorCause =
+  | { readonly _tag: "FileNotFound"; readonly path: string }
+  | { readonly _tag: "GlobNoMatches"; readonly pattern: string }
+  | { readonly _tag: "ParseFailure"; readonly path: PlanFilePath; readonly message: string }
+  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "UnsupportedHarnessKind"; readonly path: PlanFilePath; readonly kind: string }
+  | { readonly _tag: "SchemaInvalid"; readonly path: PlanFilePath; readonly errors: ReadonlyArray<string> }
+  | { readonly _tag: "DuplicateScenarioId"; readonly scenarioId: ScenarioId; readonly paths: readonly [PlanFilePath, PlanFilePath] };
+
+export function loadPlannedHarnessPath(
+  pathOrGlob: string,
+): Effect.Effect<ReadonlyArray<LoadedPlannedHarnessDocument>, PlannedHarnessLoadError, never>;
+```
+
+Intent: `loader.ts` is the only module that touches disk/globs for the new path.
+
+```ts
+// src/plans/compiler.ts
+export function compilePlannedHarnessDocuments(
+  documents: ReadonlyArray<LoadedPlannedHarnessDocument>,
+): Effect.Effect<ReadonlyArray<CompiledPlannedRun>, never, never>;
+
+export function runPlannedHarnessPath(
+  pathOrGlob: string,
+  opts?: HarnessRunOpts,
+): Effect.Effect<Report, PlannedHarnessLoadError, never>;
+```
+
+Intent: `compiler.ts` is the bridge from typed ingress to the existing `runPlans(...)` path; CLI integration stays a thin wrapper over this.
+
+## Data flow
+
+- `app/cli.ts` adds a new planned-harness entrypoint and forwards the provided file path to `runPlannedHarnessPath(...)`.
+- `plans/loader.ts` resolves the path or glob, reads YAML, parses it, and calls `plans/schema.ts` to decode one or more documents.
+- `plans/loader.ts` enforces duplicate `scenarioId` failures across all loaded documents before anything reaches execution.
+- `plans/compiler.ts` maps each decoded `prompt-workspace` document into a `PlannedRunInput` using the existing `PromptWorkspaceHarness` and the existing `RunPlan`.
+- `plans/compiler.ts` hands the compiled inputs to the existing `runPlans(...)` pipeline in `app/pipeline.ts`.
+- Existing `runPlans(...)` execution, judgment, report emission, and observability emitters remain the single runtime/report path.
+- `src/index.ts` re-exports the new `plans` surface so downstream code uses supported package imports rather than deep paths.
+
+```text
+CLI / SDK path
+    |
+    v
+loadPlannedHarnessPath(pathOrGlob)
+    |-- FileNotFound / GlobNoMatches / ParseFailure
+    |-- TopLevelNotObject / UnsupportedHarnessKind / SchemaInvalid
+    |-- DuplicateScenarioId
+    v
+compilePlannedHarnessDocuments(documents)
+    |
+    v
+runPlans(inputs, opts)
+    |-- existing RunCoordinationError folded by current pipeline
+    v
+Report + existing emitters
+```
+
+## Errors
+
+- `decodePromptWorkspacePlanSpec(...)` and `decodePlannedHarnessDocuments(...)` expose `PlannedHarnessSchemaError`.
+- `loadPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`.
+- `compilePlannedHarnessDocuments(...)` is total in this slice and returns `Effect<..., never, never>` because the only supported harness kind is the built-in `prompt-workspace` branch whose construction is local and typed.
+- `runPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`; downstream execution and judgment continue through the existing `runPlans(...)` behavior, which returns a `Report` rather than surfacing execution failures on the outer error channel.
+
+## Dependencies
+
+| library | version | license | why this one |
+|---|---:|---|---|
+| `effect` | `3.21.0` exact pin | MIT | Required to align `cc-judge` with the exact MoltZap typed runtime surface before cross-repo shared contracts can be consumed without compat glue. |
+| `@sinclair/typebox` | `0.33.22` | MIT | Existing schema library already used by `cc-judge`; this slice keeps one schema tool rather than introducing a second decoder stack. |
+| `yaml` | `2.6.1` | ISC | Existing YAML parser already used by `cc-judge`; sufficient for file-backed plan ingress. |
+| `yargs` | `17.7.2` | MIT | Existing CLI parser; the new planned-harness command remains a thin extension over the current command surface. |
+
+## Traceability
+
+| spec item | slice coverage | module / file |
+|---|---|---|
+| Goal 1 / AC: exact `effect` pin and no compat shim for `cc-judge` skew | direct | existing `package.json`, existing `src/index.ts` export surface |
+| Goal 7 / AC: `cc-judge` shared-contract output remains the default eval path | direct | existing `app/pipeline.ts`, new `plans/compiler.ts` |
+| Goal 8 / AC: generic eval substrate ownership collapses into `cc-judge` | direct | new `plans/*` surface |
+| Goal 13 / AC: distinct planned-harness YAML path instead of stretching simple scenario schema | direct | new `plans/schema.ts`, `plans/loader.ts` |
+| Goal 17 / AC: DRY single owner for generic YAML/harness ingress | direct | new `plans/*` surface and existing root export |
+| AC: `cc-judge` exposes supported file-backed planned-harness input path | direct | new `plans/index.ts`, existing `src/index.ts` |
+| AC: existing simple prompt/workspace YAML path remains supported | preserved by design | existing `core/scenario.ts`, existing `app/cli.ts` path for current `run` command |
+| AC: no duplicate generic loader ownership across repos | partial, enabling slice | new `plans/*`; MoltZap and arena migration is deferred to later architect / implement slices |
+
+## Open questions
+
+1. Q: Should the CLI expose the new file-backed planned-harness path as `cc-judge run-plans` or overload the existing `run` command with an additional mode flag?
+   Recommended default: add `run-plans` as a distinct command so the simple scenario path stays stable and operator-facing behavior is explicit.
+   Escalation target: implement-staff in `cc-judge`.
+
+2. Q: Should the loader accept both single-document YAML and arrays-of-documents in the first slice?
+   Recommended default: yes; accept either shape so a suite can live in one file or many files without inventing another wrapper format later.
+   Escalation target: implement-staff in `cc-judge`.
+
+3. Q: Should external harness kinds beyond `prompt-workspace` be first-class in this slice, or arrive later through the temporary repo-local bridge path named by the spec?
+   Recommended default: keep this slice to `prompt-workspace` plus the typed planned-harness document model; let MoltZap and arena use the short-lived bridge until a second consumer justifies upstreaming a generic harness-kind registry.
+   Escalation target: safer:spec only if the umbrella spec changes; otherwise implement-staff.

--- a/docs/architecture/2026-04-22-planned-harness-ingress.md
+++ b/docs/architecture/2026-04-22-planned-harness-ingress.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This slice adds one new `cc-judge` public surface for file-backed planned-harness execution without changing the existing prompt/workspace scenario path. The shape is: decode YAML into a typed planned-harness document, load one or more documents from disk, compile those documents into the already-existing `PlannedRunInput` substrate, and let the existing `runPlans(...)` pipeline handle execution, judging, and reporting. This is the first architected slice because it unblocks DRY eval migration in MoltZap and arena while keeping generic ownership in `cc-judge`.
+This slice adds one new `cc-judge` public ingress for file-backed planned-harness execution without changing the existing prompt/workspace scenario path: a distinct `cc-judge run-plans <plan-path-or-glob>` command plus the matching SDK helper `runPlannedHarnessPath(...)`. The top-level contract is one `PlannedHarnessDocument` object per YAML file. Multi-plan suites are expressed by loading multiple files through the existing path-or-glob fan-in, not by accepting arrays at the top level of one file. Each matched file decodes into exactly one typed planned-harness document, compiles into the already-existing `PlannedRunInput` substrate, and runs through the existing `runPlans(...)` pipeline for execution, judging, and reporting. This is the first architected slice because it unblocks DRY eval migration in MoltZap and arena while keeping generic ownership in `cc-judge`.
 
 ## Modules
 
@@ -12,12 +12,12 @@ Public surface: `PlanFilePath`, `PromptWorkspacePlanSpec`, `PlannedHarnessSpec`,
 Dependencies: `../core/types.js`, `../runner/coordinator.js`, `../app/opts.js`, `effect/Brand`.
 
 2. `src/plans/schema.ts`
-Purpose: define the decode boundary for planned-harness documents and surface typed schema failures.
-Public surface: `PlannedHarnessSchemaError`, `PlannedHarnessSchemaErrorCause`, `decodePromptWorkspacePlanSpec(...)`, `decodePlannedHarnessDocuments(...)`.
+Purpose: define the decode boundary for one planned-harness document per file and surface typed schema failures.
+Public surface: `PlannedHarnessSchemaError`, `PlannedHarnessSchemaErrorCause`, `decodePromptWorkspacePlanSpec(...)`, `decodePlannedHarnessDocument(...)`.
 Dependencies: `./types.js`, `effect`.
 
 3. `src/plans/loader.ts`
-Purpose: load YAML from files/globs, map parse failures into typed load errors, and enforce duplicate-scenario constraints across loaded plan documents.
+Purpose: load YAML from files/globs, require exactly one planned-harness document per matched file, map parse failures into typed load errors, and enforce duplicate-scenario constraints across loaded plan documents.
 Public surface: `PlannedHarnessLoadError`, `PlannedHarnessLoadErrorCause`, `loadPlannedHarnessPath(...)`.
 Dependencies: `./types.js`, `./schema.js`, `../core/types.js`, `effect`.
 
@@ -70,7 +70,7 @@ export class PlannedHarnessSchemaError extends Data.TaggedError(
 )<{ readonly cause: PlannedHarnessSchemaErrorCause }> {}
 
 export type PlannedHarnessSchemaErrorCause =
-  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "TopLevelNotDocument"; readonly path: PlanFilePath }
   | { readonly _tag: "UnsupportedHarnessKind"; readonly path: PlanFilePath; readonly kind: string }
   | { readonly _tag: "SchemaInvalid"; readonly path: PlanFilePath; readonly errors: ReadonlyArray<string> };
 
@@ -79,13 +79,13 @@ export function decodePromptWorkspacePlanSpec(
   originPath: PlanFilePath,
 ): Effect.Effect<PromptWorkspacePlanSpec, PlannedHarnessSchemaError, never>;
 
-export function decodePlannedHarnessDocuments(
+export function decodePlannedHarnessDocument(
   source: unknown,
   originPath: PlanFilePath,
-): Effect.Effect<ReadonlyArray<PlannedHarnessDocument>, PlannedHarnessSchemaError, never>;
+): Effect.Effect<PlannedHarnessDocument, PlannedHarnessSchemaError, never>;
 ```
 
-Intent: `schema.ts` owns the bytes-to-types boundary and keeps schema concerns out of file IO and execution code.
+Intent: `schema.ts` owns the bytes-to-types boundary and keeps schema concerns out of file IO and execution code. One file decodes to one `PlannedHarnessDocument`.
 
 ```ts
 // src/plans/loader.ts
@@ -97,7 +97,7 @@ export type PlannedHarnessLoadErrorCause =
   | { readonly _tag: "FileNotFound"; readonly path: string }
   | { readonly _tag: "GlobNoMatches"; readonly pattern: string }
   | { readonly _tag: "ParseFailure"; readonly path: PlanFilePath; readonly message: string }
-  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "TopLevelNotDocument"; readonly path: PlanFilePath }
   | { readonly _tag: "UnsupportedHarnessKind"; readonly path: PlanFilePath; readonly kind: string }
   | { readonly _tag: "SchemaInvalid"; readonly path: PlanFilePath; readonly errors: ReadonlyArray<string> }
   | { readonly _tag: "DuplicateScenarioId"; readonly scenarioId: ScenarioId; readonly paths: readonly [PlanFilePath, PlanFilePath] };
@@ -107,7 +107,7 @@ export function loadPlannedHarnessPath(
 ): Effect.Effect<ReadonlyArray<LoadedPlannedHarnessDocument>, PlannedHarnessLoadError, never>;
 ```
 
-Intent: `loader.ts` is the only module that touches disk/globs for the new path.
+Intent: `loader.ts` is the only module that touches disk/globs for the new path. Path fan-in happens across files; arrays-of-documents within one file are rejected at the schema boundary.
 
 ```ts
 // src/plans/compiler.ts
@@ -121,12 +121,13 @@ export function runPlannedHarnessPath(
 ): Effect.Effect<Report, PlannedHarnessLoadError, never>;
 ```
 
-Intent: `compiler.ts` is the bridge from typed ingress to the existing `runPlans(...)` path; CLI integration stays a thin wrapper over this.
+Intent: `compiler.ts` is the bridge from typed ingress to the existing `runPlans(...)` path; the distinct CLI `run-plans` command stays a thin wrapper over this SDK helper.
 
 ## Data flow
 
-- `app/cli.ts` adds a new planned-harness entrypoint and forwards the provided file path to `runPlannedHarnessPath(...)`.
-- `plans/loader.ts` resolves the path or glob, reads YAML, parses it, and calls `plans/schema.ts` to decode one or more documents.
+- `app/cli.ts` adds a distinct `run-plans <plan-path-or-glob>` command and forwards the provided file path to `runPlannedHarnessPath(...)`. The existing `run <scenario>` command remains the simple scenario ingress and is not overloaded.
+- `plans/loader.ts` resolves the path or glob, reads YAML, parses each matched file, and calls `plans/schema.ts` to decode exactly one planned-harness document from each file.
+- If a matched file does not have a single planned-harness document object at the top level, `plans/schema.ts` fails with `TopLevelNotDocument`; arrays-of-documents are rejected in this first slice.
 - `plans/loader.ts` enforces duplicate `scenarioId` failures across all loaded documents before anything reaches execution.
 - `plans/compiler.ts` maps each decoded `prompt-workspace` document into a `PlannedRunInput` using the existing `PromptWorkspaceHarness` and the existing `RunPlan`.
 - `plans/compiler.ts` hands the compiled inputs to the existing `runPlans(...)` pipeline in `app/pipeline.ts`.
@@ -134,12 +135,12 @@ Intent: `compiler.ts` is the bridge from typed ingress to the existing `runPlans
 - `src/index.ts` re-exports the new `plans` surface so downstream code uses supported package imports rather than deep paths.
 
 ```text
-CLI / SDK path
+cc-judge run-plans <plan-path-or-glob>
     |
     v
 loadPlannedHarnessPath(pathOrGlob)
     |-- FileNotFound / GlobNoMatches / ParseFailure
-    |-- TopLevelNotObject / UnsupportedHarnessKind / SchemaInvalid
+    |-- TopLevelNotDocument / UnsupportedHarnessKind / SchemaInvalid
     |-- DuplicateScenarioId
     v
 compilePlannedHarnessDocuments(documents)
@@ -153,10 +154,11 @@ Report + existing emitters
 
 ## Errors
 
-- `decodePromptWorkspacePlanSpec(...)` and `decodePlannedHarnessDocuments(...)` expose `PlannedHarnessSchemaError`.
+- `decodePromptWorkspacePlanSpec(...)` and `decodePlannedHarnessDocument(...)` expose `PlannedHarnessSchemaError`.
+- `TopLevelNotDocument` means the YAML root is not one planned-harness document object with `plan` and `harness`; suites spanning multiple plans must use multiple files matched by the input path or glob.
 - `loadPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`.
 - `compilePlannedHarnessDocuments(...)` is total in this slice and returns `Effect<..., never, never>` because the only supported harness kind is the built-in `prompt-workspace` branch whose construction is local and typed.
-- `runPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`; downstream execution and judgment continue through the existing `runPlans(...)` behavior, which returns a `Report` rather than surfacing execution failures on the outer error channel.
+- `runPlannedHarnessPath(...)` exposes `PlannedHarnessLoadError`; it is the SDK surface behind the distinct CLI `run-plans` ingress. Downstream execution and judgment continue through the existing `runPlans(...)` behavior, which returns a `Report` rather than surfacing execution failures on the outer error channel.
 
 ## Dependencies
 
@@ -165,7 +167,7 @@ Report + existing emitters
 | `effect` | `3.21.0` exact pin | MIT | Required to align `cc-judge` with the exact MoltZap typed runtime surface before cross-repo shared contracts can be consumed without compat glue. |
 | `@sinclair/typebox` | `0.33.22` | MIT | Existing schema library already used by `cc-judge`; this slice keeps one schema tool rather than introducing a second decoder stack. |
 | `yaml` | `2.6.1` | ISC | Existing YAML parser already used by `cc-judge`; sufficient for file-backed plan ingress. |
-| `yargs` | `17.7.2` | MIT | Existing CLI parser; the new planned-harness command remains a thin extension over the current command surface. |
+| `yargs` | `17.7.2` | MIT | Existing CLI parser; the new `run-plans` command remains a thin extension over the current command surface without overloading `run`. |
 
 ## Traceability
 
@@ -176,20 +178,10 @@ Report + existing emitters
 | Goal 8 / AC: generic eval substrate ownership collapses into `cc-judge` | direct | new `plans/*` surface |
 | Goal 13 / AC: distinct planned-harness YAML path instead of stretching simple scenario schema | direct | new `plans/schema.ts`, `plans/loader.ts` |
 | Goal 17 / AC: DRY single owner for generic YAML/harness ingress | direct | new `plans/*` surface and existing root export |
-| AC: `cc-judge` exposes supported file-backed planned-harness input path | direct | new `plans/index.ts`, existing `src/index.ts` |
-| AC: existing simple prompt/workspace YAML path remains supported | preserved by design | existing `core/scenario.ts`, existing `app/cli.ts` path for current `run` command |
+| AC: `cc-judge` exposes supported file-backed planned-harness input path | direct | new `plans/index.ts`, `plans/compiler.ts`, existing `app/cli.ts` distinct `run-plans` command |
+| AC: existing simple prompt/workspace YAML path remains supported | preserved by design | existing `core/scenario.ts`, existing `app/cli.ts` `run` command remains unchanged |
 | AC: no duplicate generic loader ownership across repos | partial, enabling slice | new `plans/*`; MoltZap and arena migration is deferred to later architect / implement slices |
 
 ## Open questions
 
-1. Q: Should the CLI expose the new file-backed planned-harness path as `cc-judge run-plans` or overload the existing `run` command with an additional mode flag?
-   Recommended default: add `run-plans` as a distinct command so the simple scenario path stays stable and operator-facing behavior is explicit.
-   Escalation target: implement-staff in `cc-judge`.
-
-2. Q: Should the loader accept both single-document YAML and arrays-of-documents in the first slice?
-   Recommended default: yes; accept either shape so a suite can live in one file or many files without inventing another wrapper format later.
-   Escalation target: implement-staff in `cc-judge`.
-
-3. Q: Should external harness kinds beyond `prompt-workspace` be first-class in this slice, or arrive later through the temporary repo-local bridge path named by the spec?
-   Recommended default: keep this slice to `prompt-workspace` plus the typed planned-harness document model; let MoltZap and arena use the short-lived bridge until a second consumer justifies upstreaming a generic harness-kind registry.
-   Escalation target: safer:spec only if the umbrella spec changes; otherwise implement-staff.
+None. This slice explicitly freezes one `PlannedHarnessDocument` object per file and a distinct `cc-judge run-plans` ingress while keeping the existing `run` scenario command unchanged. Additional harness kinds require a later architect slice if the governing spec expands.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.1.45",
     "@sinclair/typebox": "0.33.22",
     "braintrust": "0.0.180",
-    "effect": "3.11.10",
+    "effect": "3.21.0",
     "glob": "11.0.0",
     "proper-lockfile": "4.1.2",
     "yaml": "2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 0.0.180
         version: 0.0.180(react@19.2.5)(sswr@2.2.0(svelte@5.55.4(@typescript-eslint/types@8.58.2)))(svelte@5.55.4(@typescript-eslint/types@8.58.2))(vue@3.5.32(typescript@5.6.3))(zod@4.3.6)
       effect:
-        specifier: 3.11.10
-        version: 3.11.10
+        specifier: 3.21.0
+        version: 3.21.0
       glob:
         specifier: 11.0.0
         version: 11.0.0
@@ -1096,6 +1096,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stryker-mutator/api@9.6.1':
     resolution: {integrity: sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==}
     engines: {node: '>=20.0.0'}
@@ -1653,8 +1656,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  effect@3.11.10:
-    resolution: {integrity: sha512-0gsqCmJh+qaFCxbiKwYVIo3o8CAgI/V5mQjctDZXLOUmnpnpqVMuq8jJVLY412rEYmGvpvvhWY+d8d6mdR9T2w==}
+  effect@3.21.0:
+    resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
 
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
@@ -3647,6 +3650,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stryker-mutator/api@9.6.1':
     dependencies:
       mutation-testing-metrics: 3.7.3
@@ -4329,8 +4334,9 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  effect@3.11.10:
+  effect@3.21.0:
     dependencies:
+      '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
   electron-to-chromium@1.5.340: {}

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -10,7 +10,14 @@ import { scenarioLoader } from "../core/scenario.js";
 import type { Scenario } from "../core/schema.js";
 import type { Trace } from "../core/schema.js";
 import { AnthropicJudgeBackend, JUDGE_SYSTEM_PROMPT } from "../judge/index.js";
-import { DockerRunner, SubprocessRunner, type AgentRunner } from "../runner/index.js";
+import {
+  DockerRunner,
+  DockerRuntime,
+  SubprocessRunner,
+  SubprocessRuntime,
+  type AgentRunner,
+  type AgentRuntime,
+} from "../runner/index.js";
 import { BraintrustEmitter, PromptfooEmitter, type ObservabilityEmitter } from "../emit/observability.js";
 import { getTraceAdapter, type TraceFormat } from "../emit/trace-adapter.js";
 import { glob as doGlob } from "glob";
@@ -18,6 +25,7 @@ import { RunnerResolutionError } from "../core/errors.js";
 import { runScenarios, scoreTraces } from "./pipeline.js";
 import { inspectRun, type InspectErrorCause } from "./inspect.js";
 import { absurd } from "../core/types.js";
+import { runPlannedHarnessPath } from "../plans/compiler.js";
 
 export type CliExitCode = 0 | 1 | 2;
 
@@ -46,6 +54,22 @@ export interface ScoreCliArgs {
   readonly judge: string;
   readonly judgeBackend: string;
   readonly judgeRubric?: string;
+  readonly results: string;
+  readonly githubComment?: number;
+  readonly githubCommentArtifactUrl?: string;
+  readonly concurrency: number;
+  readonly logLevel: "debug" | "info" | "warn" | "error";
+  readonly totalTimeoutMs?: number;
+  readonly emitBraintrust: boolean;
+  readonly emitPromptfoo?: string;
+}
+
+interface RunPlansCliArgs {
+  readonly planPath: string;
+  readonly runtime: "docker" | "subprocess";
+  readonly bin?: string;
+  readonly judge: string;
+  readonly judgeBackend: string;
   readonly results: string;
   readonly githubComment?: number;
   readonly githubCommentArtifactUrl?: string;
@@ -89,6 +113,18 @@ function buildRunner(args: RunCliArgs): Effect.Effect<AgentRunner, RunnerResolut
     );
   }
   return Effect.succeed(new DockerRunner({ image: args.image }));
+}
+
+function buildRuntime(args: RunPlansCliArgs): Effect.Effect<AgentRuntime, RunnerResolutionError, never> {
+  if (args.runtime === "subprocess") {
+    if (args.bin === undefined) {
+      return Effect.fail(
+        new RunnerResolutionError({ cause: { _tag: "InvalidRuntime", value: "subprocess: missing --bin" } }),
+      );
+    }
+    return Effect.succeed(new SubprocessRuntime({ bin: args.bin }));
+  }
+  return Effect.succeed(new DockerRuntime());
 }
 
 export function runCommand(args: RunCliArgs): Effect.Effect<CliExitCode, never, never> {
@@ -180,6 +216,69 @@ export function scoreCommand(args: ScoreCliArgs): Effect.Effect<CliExitCode, nev
         : {}),
       ...(args.totalTimeoutMs !== undefined ? { totalTimeoutMs: args.totalTimeoutMs } : {}),
     });
+    process.stdout.write(
+      `cc-judge: ${String(report.summary.passed)}/${String(report.summary.total)} passed\n`,
+    );
+    return (report.summary.failed === 0 ? 0 : 1) as CliExitCode;
+  });
+}
+
+function parseRunPlansArgs(raw: unknown): RunPlansCliArgs {
+  const r = asObject(raw);
+  const runtime = r["runtime"] === "subprocess" ? "subprocess" : "docker";
+  const logLevel = (r["logLevel"] === "debug" || r["logLevel"] === "info" || r["logLevel"] === "warn" || r["logLevel"] === "error")
+    ? r["logLevel"]
+    : "info";
+  return {
+    planPath: typeof r["planPath"] === "string" ? r["planPath"] : "",
+    runtime,
+    ...(typeof r["bin"] === "string" ? { bin: r["bin"] } : {}),
+    judge: typeof r["judge"] === "string" ? r["judge"] : "claude-opus-4-7",
+    judgeBackend: typeof r["judgeBackend"] === "string" ? r["judgeBackend"] : "anthropic",
+    results: typeof r["results"] === "string" ? r["results"] : "./eval-results",
+    ...(typeof r["githubComment"] === "number" ? { githubComment: r["githubComment"] } : {}),
+    ...(typeof r["githubCommentArtifactUrl"] === "string"
+      ? { githubCommentArtifactUrl: r["githubCommentArtifactUrl"] }
+      : {}),
+    concurrency: typeof r["concurrency"] === "number" ? r["concurrency"] : 1,
+    logLevel,
+    ...(typeof r["totalTimeoutMs"] === "number" ? { totalTimeoutMs: r["totalTimeoutMs"] } : {}),
+    emitBraintrust: r["emitBraintrust"] === true,
+    ...(typeof r["emitPromptfoo"] === "string" ? { emitPromptfoo: r["emitPromptfoo"] } : {}),
+  };
+}
+
+function runPlansCommand(args: RunPlansCliArgs): Effect.Effect<CliExitCode, never, never> {
+  return Effect.gen(function* () {
+    const runtimeRes = yield* Effect.either(buildRuntime(args));
+    if (runtimeRes._tag === "Left") {
+      const cause = runtimeRes.left.cause;
+      const detail = cause._tag === "InvalidRuntime" ? cause.value : cause._tag;
+      process.stderr.write(`cc-judge: runtime resolution failed: ${detail}\n`);
+      return 2 as CliExitCode;
+    }
+    const judge = new AnthropicJudgeBackend({ model: args.judge });
+    const emitters = buildObservability(args.emitBraintrust, args.emitPromptfoo);
+    const runRes = yield* Effect.either(
+      runPlannedHarnessPath(args.planPath, {
+        runtime: runtimeRes.right,
+        judge,
+        resultsDir: args.results,
+        concurrency: args.concurrency,
+        emitters,
+        logLevel: args.logLevel,
+        ...(args.githubComment !== undefined ? { githubComment: args.githubComment } : {}),
+        ...(args.githubCommentArtifactUrl !== undefined
+          ? { githubCommentArtifactUrl: args.githubCommentArtifactUrl }
+          : {}),
+        ...(args.totalTimeoutMs !== undefined ? { totalTimeoutMs: args.totalTimeoutMs } : {}),
+      }),
+    );
+    if (runRes._tag === "Left") {
+      process.stderr.write(`cc-judge: planned-harness load failed: ${runRes.left.cause._tag}\n`);
+      return 2 as CliExitCode;
+    }
+    const report = runRes.right;
     process.stdout.write(
       `cc-judge: ${String(report.summary.passed)}/${String(report.summary.total)} passed\n`,
     );
@@ -328,6 +427,22 @@ export function main(argv: ReadonlyArray<string>): Effect.Effect<CliExitCode, ne
           .option("emit-braintrust", { type: "boolean", default: false })
           .option("emit-promptfoo", { type: "string" }),
       )
+      .command("run-plans <planPath>", "Run planned harness documents", (y) =>
+        y
+          .positional("planPath", { type: "string", demandOption: true })
+          .option("runtime", { choices: ["docker", "subprocess"] as const, default: "docker" })
+          .option("bin", { type: "string" })
+          .option("judge", { type: "string", default: "claude-opus-4-7" })
+          .option("judge-backend", { type: "string", default: "anthropic" })
+          .option("results", { type: "string", default: "./eval-results" })
+          .option("github-comment", { type: "number" })
+          .option("github-comment-artifact-url", { type: "string" })
+          .option("concurrency", { type: "number", default: 1 })
+          .option("log-level", { choices: ["debug", "info", "warn", "error"] as const, default: "info" })
+          .option("total-timeout-ms", { type: "number" })
+          .option("emit-braintrust", { type: "boolean", default: false })
+          .option("emit-promptfoo", { type: "string" }),
+      )
       .command("score <traces>", "Score traces", (y) =>
         y
           .positional("traces", { type: "string", demandOption: true })
@@ -358,6 +473,8 @@ export function main(argv: ReadonlyArray<string>): Effect.Effect<CliExitCode, ne
     switch (command) {
       case "run":
         return runCommand(parseRunArgs(parsed));
+      case "run-plans":
+        return runPlansCommand(parseRunPlansArgs(parsed));
       case "score":
         return scoreCommand(parseScoreArgs(parsed));
       case "inspect":

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from "./runner/index.js";
 export * from "./judge/index.js";
 export * from "./emit/index.js";
 export * from "./app/index.js";
+export * from "./plans/index.js";

--- a/src/plans/compiler.ts
+++ b/src/plans/compiler.ts
@@ -1,18 +1,33 @@
 import { Effect } from "effect";
 import type { HarnessRunOpts } from "../app/opts.js";
+import { runPlans } from "../app/pipeline.js";
 import type { Report } from "../core/schema.js";
+import { PromptWorkspaceHarness } from "../runner/coordinator.js";
+import { loadPlannedHarnessPath } from "./loader.js";
 import type { LoadedPlannedHarnessDocument, CompiledPlannedRun } from "./types.js";
 import type { PlannedHarnessLoadError } from "./loader.js";
 
 export function compilePlannedHarnessDocuments(
-  _documents: ReadonlyArray<LoadedPlannedHarnessDocument>,
+  documents: ReadonlyArray<LoadedPlannedHarnessDocument>,
 ): Effect.Effect<ReadonlyArray<CompiledPlannedRun>, never, never> {
-  throw new Error("not implemented");
+  return Effect.succeed(
+    documents.map((document) => ({
+      sourcePath: document.sourcePath,
+      input: {
+        plan: document.document.plan,
+        harness: new PromptWorkspaceHarness(document.document.harness.config),
+      },
+    })),
+  );
 }
 
 export function runPlannedHarnessPath(
-  _pathOrGlob: string,
-  _opts: HarnessRunOpts = {},
+  pathOrGlob: string,
+  opts: HarnessRunOpts = {},
 ): Effect.Effect<Report, PlannedHarnessLoadError, never> {
-  throw new Error("not implemented");
+  return loadPlannedHarnessPath(pathOrGlob).pipe(
+    Effect.flatMap((documents) => compilePlannedHarnessDocuments(documents)),
+    Effect.map((compiled) => compiled.map((entry) => entry.input)),
+    Effect.flatMap((inputs) => runPlans(inputs, opts)),
+  );
 }

--- a/src/plans/compiler.ts
+++ b/src/plans/compiler.ts
@@ -1,0 +1,18 @@
+import { Effect } from "effect";
+import type { HarnessRunOpts } from "../app/opts.js";
+import type { Report } from "../core/schema.js";
+import type { LoadedPlannedHarnessDocument, CompiledPlannedRun } from "./types.js";
+import type { PlannedHarnessLoadError } from "./loader.js";
+
+export function compilePlannedHarnessDocuments(
+  _documents: ReadonlyArray<LoadedPlannedHarnessDocument>,
+): Effect.Effect<ReadonlyArray<CompiledPlannedRun>, never, never> {
+  throw new Error("not implemented");
+}
+
+export function runPlannedHarnessPath(
+  _pathOrGlob: string,
+  _opts: HarnessRunOpts = {},
+): Effect.Effect<Report, PlannedHarnessLoadError, never> {
+  throw new Error("not implemented");
+}

--- a/src/plans/index.ts
+++ b/src/plans/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./schema.js";
+export * from "./loader.js";
+export * from "./compiler.js";

--- a/src/plans/loader.ts
+++ b/src/plans/loader.ts
@@ -20,7 +20,7 @@ export type PlannedHarnessLoadErrorCause =
       readonly message: string;
     }
   | {
-      readonly _tag: "TopLevelNotObject";
+      readonly _tag: "TopLevelNotDocument";
       readonly path: PlanFilePath;
     }
   | {

--- a/src/plans/loader.ts
+++ b/src/plans/loader.ts
@@ -1,0 +1,50 @@
+import { Data, Effect } from "effect";
+import type { ScenarioId } from "../core/types.js";
+import type {
+  LoadedPlannedHarnessDocument,
+  PlanFilePath,
+} from "./types.js";
+
+export class PlannedHarnessLoadError extends Data.TaggedError(
+  "PlannedHarnessLoadError",
+)<{
+  readonly cause: PlannedHarnessLoadErrorCause;
+}> {}
+
+export type PlannedHarnessLoadErrorCause =
+  | { readonly _tag: "FileNotFound"; readonly path: string }
+  | { readonly _tag: "GlobNoMatches"; readonly pattern: string }
+  | {
+      readonly _tag: "ParseFailure";
+      readonly path: PlanFilePath;
+      readonly message: string;
+    }
+  | {
+      readonly _tag: "TopLevelNotObject";
+      readonly path: PlanFilePath;
+    }
+  | {
+      readonly _tag: "UnsupportedHarnessKind";
+      readonly path: PlanFilePath;
+      readonly kind: string;
+    }
+  | {
+      readonly _tag: "SchemaInvalid";
+      readonly path: PlanFilePath;
+      readonly errors: ReadonlyArray<string>;
+    }
+  | {
+      readonly _tag: "DuplicateScenarioId";
+      readonly scenarioId: ScenarioId;
+      readonly paths: readonly [PlanFilePath, PlanFilePath];
+    };
+
+export function loadPlannedHarnessPath(
+  _pathOrGlob: string,
+): Effect.Effect<
+  ReadonlyArray<LoadedPlannedHarnessDocument>,
+  PlannedHarnessLoadError,
+  never
+> {
+  throw new Error("not implemented");
+}

--- a/src/plans/loader.ts
+++ b/src/plans/loader.ts
@@ -1,9 +1,15 @@
 import { Data, Effect } from "effect";
+import { glob as doGlob } from "glob";
+import { readFile, stat } from "node:fs/promises";
+import * as path from "node:path";
+import * as YAML from "yaml";
 import type { ScenarioId } from "../core/types.js";
+import { decodePlannedHarnessDocument, type PlannedHarnessSchemaError } from "./schema.js";
 import type {
   LoadedPlannedHarnessDocument,
   PlanFilePath,
 } from "./types.js";
+import { PlanFilePath as PlanFilePathBrand } from "./types.js";
 
 export class PlannedHarnessLoadError extends Data.TaggedError(
   "PlannedHarnessLoadError",
@@ -39,12 +45,142 @@ export type PlannedHarnessLoadErrorCause =
       readonly paths: readonly [PlanFilePath, PlanFilePath];
     };
 
+const YAML_GLOB = "**/*.{yaml,yml}";
+
+function isGlobPattern(value: string): boolean {
+  return /[*?[\]{}]/.test(value);
+}
+
+function parseFailure(path: PlanFilePath, error: unknown): PlannedHarnessLoadError {
+  return new PlannedHarnessLoadError({
+    cause: {
+      _tag: "ParseFailure",
+      path,
+      message: error instanceof Error ? error.message : String(error),
+    },
+  });
+}
+
+const globEff = (pattern: string, cwd?: string): Effect.Effect<ReadonlyArray<string>, PlannedHarnessLoadError, never> =>
+  Effect.tryPromise({
+    try: () => doGlob(pattern, cwd !== undefined ? { cwd, absolute: true, nodir: true } : { absolute: true, nodir: true }),
+    catch: (error) => {
+      const syntheticPath = PlanFilePathBrand(path.resolve(pattern));
+      return parseFailure(syntheticPath, error);
+    },
+  }).pipe(Effect.map((matches) => matches.slice().sort()));
+
+const statEff = (abs: string): Effect.Effect<{ readonly isDirectory: boolean } | null, never, never> =>
+  Effect.tryPromise({
+    try: () => stat(abs),
+    catch: () => undefined,
+  }).pipe(
+    Effect.map((entry) => ({ isDirectory: entry.isDirectory() })),
+    Effect.catchAll(() => Effect.succeed(null)),
+  );
+
+const resolvePaths = (pathOrGlob: string): Effect.Effect<ReadonlyArray<string>, PlannedHarnessLoadError, never> =>
+  Effect.gen(function* () {
+    if (isGlobPattern(pathOrGlob)) {
+      return yield* globEff(pathOrGlob);
+    }
+    const abs = path.resolve(pathOrGlob);
+    const entry = yield* statEff(abs);
+    if (entry === null) {
+      return [];
+    }
+    if (entry.isDirectory) {
+      return yield* globEff(YAML_GLOB, abs);
+    }
+    return [abs];
+  });
+
+function readFileEff(pathValue: PlanFilePath): Effect.Effect<string, PlannedHarnessLoadError, never> {
+  return Effect.tryPromise({
+    try: () => readFile(pathValue, "utf8"),
+    catch: (error) =>
+      new PlannedHarnessLoadError({
+        cause: error instanceof Error && "code" in error && (error as { readonly code?: string }).code === "ENOENT"
+          ? { _tag: "FileNotFound", path: pathValue }
+          : {
+              _tag: "ParseFailure",
+              path: pathValue,
+              message: error instanceof Error ? error.message : String(error),
+            },
+      }),
+  });
+}
+
+function parseYaml(source: string, originPath: PlanFilePath): Effect.Effect<unknown, PlannedHarnessLoadError, never> {
+  return Effect.suspend(() => {
+    try {
+      return Effect.succeed(YAML.parse(source));
+    } catch (error) {
+      return Effect.fail(parseFailure(originPath, error));
+    }
+  });
+}
+
+function mapSchemaError(error: PlannedHarnessSchemaError): PlannedHarnessLoadError {
+  return new PlannedHarnessLoadError({ cause: error.cause });
+}
+
+function loadOne(absPath: string): Effect.Effect<LoadedPlannedHarnessDocument, PlannedHarnessLoadError, never> {
+  const sourcePath = PlanFilePathBrand(absPath);
+  return readFileEff(sourcePath).pipe(
+    Effect.flatMap((source) => parseYaml(source, sourcePath)),
+    Effect.flatMap((parsed) =>
+      decodePlannedHarnessDocument(parsed, sourcePath).pipe(
+        Effect.mapError((error) => mapSchemaError(error)),
+      ),
+    ),
+    Effect.map((document) => ({
+      sourcePath,
+      document,
+    })),
+  );
+}
+
+function enforceUniqueScenarioIds(
+  documents: ReadonlyArray<LoadedPlannedHarnessDocument>,
+): Effect.Effect<ReadonlyArray<LoadedPlannedHarnessDocument>, PlannedHarnessLoadError, never> {
+  const seen = new Map<string, PlanFilePath>();
+  for (const document of documents) {
+    const scenarioId = document.document.plan.scenarioId;
+    const previousPath = seen.get(scenarioId);
+    if (previousPath !== undefined) {
+      return Effect.fail(
+        new PlannedHarnessLoadError({
+          cause: {
+            _tag: "DuplicateScenarioId",
+            scenarioId,
+            paths: [previousPath, document.sourcePath],
+          },
+        }),
+      );
+    }
+    seen.set(scenarioId, document.sourcePath);
+  }
+  return Effect.succeed(documents);
+}
+
 export function loadPlannedHarnessPath(
-  _pathOrGlob: string,
+  pathOrGlob: string,
 ): Effect.Effect<
   ReadonlyArray<LoadedPlannedHarnessDocument>,
   PlannedHarnessLoadError,
   never
 > {
-  throw new Error("not implemented");
+  return resolvePaths(pathOrGlob).pipe(
+    Effect.flatMap((paths) => {
+      if (paths.length === 0) {
+        return isGlobPattern(pathOrGlob)
+          ? Effect.fail(new PlannedHarnessLoadError({ cause: { _tag: "GlobNoMatches", pattern: pathOrGlob } }))
+          : Effect.fail(new PlannedHarnessLoadError({ cause: { _tag: "FileNotFound", path: pathOrGlob } }));
+      }
+      return Effect.forEach(paths, (resolvedPath) => loadOne(resolvedPath)).pipe(
+        Effect.flatMap((loaded) => enforceUniqueScenarioIds(loaded)),
+      );
+    }),
+  );
 }

--- a/src/plans/schema.ts
+++ b/src/plans/schema.ts
@@ -1,0 +1,43 @@
+import { Data, Effect } from "effect";
+import type {
+  PlanFilePath,
+  PlannedHarnessDocument,
+  PromptWorkspacePlanSpec,
+} from "./types.js";
+
+export class PlannedHarnessSchemaError extends Data.TaggedError(
+  "PlannedHarnessSchemaError",
+)<{
+  readonly cause: PlannedHarnessSchemaErrorCause;
+}> {}
+
+export type PlannedHarnessSchemaErrorCause =
+  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | {
+      readonly _tag: "UnsupportedHarnessKind";
+      readonly path: PlanFilePath;
+      readonly kind: string;
+    }
+  | {
+      readonly _tag: "SchemaInvalid";
+      readonly path: PlanFilePath;
+      readonly errors: ReadonlyArray<string>;
+    };
+
+export function decodePromptWorkspacePlanSpec(
+  _source: unknown,
+  _originPath: PlanFilePath,
+): Effect.Effect<PromptWorkspacePlanSpec, PlannedHarnessSchemaError, never> {
+  throw new Error("not implemented");
+}
+
+export function decodePlannedHarnessDocuments(
+  _source: unknown,
+  _originPath: PlanFilePath,
+): Effect.Effect<
+  ReadonlyArray<PlannedHarnessDocument>,
+  PlannedHarnessSchemaError,
+  never
+> {
+  throw new Error("not implemented");
+}

--- a/src/plans/schema.ts
+++ b/src/plans/schema.ts
@@ -1,4 +1,19 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 import { Data, Effect } from "effect";
+import {
+  RunPlanSchema,
+  WorkspaceFileSchema,
+  formatSchemaErrors,
+  type RunPlanStatic,
+} from "../core/schema.js";
+import {
+  AgentId,
+  ProjectId,
+  ScenarioId,
+  type AgentDeclaration,
+  type RunPlan,
+} from "../core/types.js";
 import type {
   PlanFilePath,
   PlannedHarnessDocument,
@@ -24,16 +39,173 @@ export type PlannedHarnessSchemaErrorCause =
       readonly errors: ReadonlyArray<string>;
     };
 
-export function decodePromptWorkspacePlanSpec(
-  _source: unknown,
-  _originPath: PlanFilePath,
+const PromptWorkspaceHarnessConfigSchema = Type.Object({
+  prompts: Type.Array(Type.String({ minLength: 1 }), { minItems: 1 }),
+  workspace: Type.Optional(Type.Array(WorkspaceFileSchema)),
+  turnTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+});
+
+const PromptWorkspacePlanSpecSchema = Type.Object({
+  kind: Type.Literal("prompt-workspace"),
+  config: PromptWorkspaceHarnessConfigSchema,
+});
+
+const PlannedHarnessDocumentSchema = Type.Object({
+  plan: RunPlanSchema,
+  harness: PromptWorkspacePlanSpecSchema,
+});
+
+type PromptWorkspacePlanSpecStatic = Static<typeof PromptWorkspacePlanSpecSchema>;
+type PlannedHarnessDocumentStatic = Static<typeof PlannedHarnessDocumentSchema>;
+
+function schemaInvalid(
+  path: PlanFilePath,
+  errors: ReadonlyArray<string>,
+): PlannedHarnessSchemaError {
+  return new PlannedHarnessSchemaError({
+    cause: {
+      _tag: "SchemaInvalid",
+      path,
+      errors,
+    },
+  });
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeWithSchema<T>(
+  schema: Parameters<typeof Value.Errors>[0],
+  source: unknown,
+  originPath: PlanFilePath,
+): Effect.Effect<T, PlannedHarnessSchemaError, never> {
+  const errors = formatSchemaErrors(Value.Errors(schema, source));
+  if (errors.length > 0) {
+    return Effect.fail(schemaInvalid(originPath, errors));
+  }
+  return Effect.succeed(Value.Decode(schema, source) as T);
+}
+
+function toPromptWorkspacePlanSpec(
+  decoded: PromptWorkspacePlanSpecStatic,
+  originPath: PlanFilePath,
 ): Effect.Effect<PromptWorkspacePlanSpec, PlannedHarnessSchemaError, never> {
-  throw new Error("not implemented");
+  const [firstPrompt, ...restPrompts] = decoded.config.prompts;
+  if (firstPrompt === undefined) {
+    return Effect.fail(schemaInvalid(originPath, ["/config/prompts must contain at least one prompt"]));
+  }
+  const prompts: readonly [string, ...string[]] = [firstPrompt, ...restPrompts];
+  return Effect.succeed({
+    kind: "prompt-workspace",
+    config: {
+      prompts,
+      ...(decoded.config.workspace !== undefined ? { workspace: decoded.config.workspace } : {}),
+      ...(decoded.config.turnTimeoutMs !== undefined
+        ? { turnTimeoutMs: decoded.config.turnTimeoutMs }
+        : {}),
+    },
+  });
+}
+
+function toAgentDeclaration(agent: RunPlanStatic["agents"][number]): AgentDeclaration {
+  return {
+    id: AgentId(agent.id),
+    name: agent.name,
+    ...(agent.role !== undefined ? { role: agent.role } : {}),
+    artifact: agent.artifact,
+    promptInputs: agent.promptInputs,
+    ...(agent.metadata !== undefined ? { metadata: agent.metadata } : {}),
+  };
+}
+
+function toRunPlan(
+  decoded: RunPlanStatic,
+  originPath: PlanFilePath,
+): Effect.Effect<RunPlan, PlannedHarnessSchemaError, never> {
+  const agents = decoded.agents.map((agent) => toAgentDeclaration(agent));
+  const [firstAgent, ...restAgents] = agents;
+  if (firstAgent === undefined) {
+    return Effect.fail(schemaInvalid(originPath, ["/plan/agents must contain at least one agent"]));
+  }
+  const typedAgents: readonly [AgentDeclaration, ...AgentDeclaration[]] = [firstAgent, ...restAgents];
+  return Effect.succeed({
+    project: ProjectId(decoded.project),
+    scenarioId: ScenarioId(decoded.scenarioId),
+    name: decoded.name,
+    description: decoded.description,
+    agents: typedAgents,
+    requirements: decoded.requirements,
+    ...(decoded.metadata !== undefined ? { metadata: decoded.metadata } : {}),
+  });
+}
+
+export function decodePromptWorkspacePlanSpec(
+  source: unknown,
+  originPath: PlanFilePath,
+): Effect.Effect<PromptWorkspacePlanSpec, PlannedHarnessSchemaError, never> {
+  if (isRecord(source)) {
+    const kind = source["kind"];
+    if (typeof kind === "string" && kind !== "prompt-workspace") {
+      return Effect.fail(
+        new PlannedHarnessSchemaError({
+          cause: {
+            _tag: "UnsupportedHarnessKind",
+            path: originPath,
+            kind,
+          },
+        }),
+      );
+    }
+  }
+  return decodeWithSchema<PromptWorkspacePlanSpecStatic>(
+    PromptWorkspacePlanSpecSchema,
+    source,
+    originPath,
+  ).pipe(Effect.flatMap((decoded) => toPromptWorkspacePlanSpec(decoded, originPath)));
 }
 
 export function decodePlannedHarnessDocument(
-  _source: unknown,
-  _originPath: PlanFilePath,
+  source: unknown,
+  originPath: PlanFilePath,
 ): Effect.Effect<PlannedHarnessDocument, PlannedHarnessSchemaError, never> {
-  throw new Error("not implemented");
+  if (!isRecord(source) || !("plan" in source) || !("harness" in source)) {
+    return Effect.fail(
+      new PlannedHarnessSchemaError({
+        cause: {
+          _tag: "TopLevelNotDocument",
+          path: originPath,
+        },
+      }),
+    );
+  }
+
+  const harnessSource = source["harness"];
+  if (isRecord(harnessSource)) {
+    const kind = harnessSource["kind"];
+    if (typeof kind === "string" && kind !== "prompt-workspace") {
+      return Effect.fail(
+        new PlannedHarnessSchemaError({
+          cause: {
+            _tag: "UnsupportedHarnessKind",
+            path: originPath,
+            kind,
+          },
+        }),
+      );
+    }
+  }
+
+  return decodeWithSchema<PlannedHarnessDocumentStatic>(
+    PlannedHarnessDocumentSchema,
+    source,
+    originPath,
+  ).pipe(
+    Effect.flatMap((decoded) =>
+      Effect.all({
+        plan: toRunPlan(decoded.plan, originPath),
+        harness: toPromptWorkspacePlanSpec(decoded.harness, originPath),
+      }),
+    ),
+  );
 }

--- a/src/plans/schema.ts
+++ b/src/plans/schema.ts
@@ -12,7 +12,7 @@ export class PlannedHarnessSchemaError extends Data.TaggedError(
 }> {}
 
 export type PlannedHarnessSchemaErrorCause =
-  | { readonly _tag: "TopLevelNotObject"; readonly path: PlanFilePath }
+  | { readonly _tag: "TopLevelNotDocument"; readonly path: PlanFilePath }
   | {
       readonly _tag: "UnsupportedHarnessKind";
       readonly path: PlanFilePath;
@@ -31,13 +31,9 @@ export function decodePromptWorkspacePlanSpec(
   throw new Error("not implemented");
 }
 
-export function decodePlannedHarnessDocuments(
+export function decodePlannedHarnessDocument(
   _source: unknown,
   _originPath: PlanFilePath,
-): Effect.Effect<
-  ReadonlyArray<PlannedHarnessDocument>,
-  PlannedHarnessSchemaError,
-  never
-> {
+): Effect.Effect<PlannedHarnessDocument, PlannedHarnessSchemaError, never> {
   throw new Error("not implemented");
 }

--- a/src/plans/types.ts
+++ b/src/plans/types.ts
@@ -1,0 +1,29 @@
+import { Brand } from "effect";
+import type { PlannedRunInput } from "../app/opts.js";
+import type { RunPlan } from "../core/types.js";
+import type { PromptWorkspaceHarnessConfig } from "../runner/coordinator.js";
+
+export type PlanFilePath = string & Brand.Brand<"PlanFilePath">;
+export const PlanFilePath = Brand.nominal<PlanFilePath>();
+
+export interface PromptWorkspacePlanSpec {
+  readonly kind: "prompt-workspace";
+  readonly config: PromptWorkspaceHarnessConfig;
+}
+
+export type PlannedHarnessSpec = PromptWorkspacePlanSpec;
+
+export interface PlannedHarnessDocument {
+  readonly plan: RunPlan;
+  readonly harness: PlannedHarnessSpec;
+}
+
+export interface LoadedPlannedHarnessDocument {
+  readonly sourcePath: PlanFilePath;
+  readonly document: PlannedHarnessDocument;
+}
+
+export interface CompiledPlannedRun {
+  readonly sourcePath: PlanFilePath;
+  readonly input: PlannedRunInput;
+}

--- a/tests/plans.test.ts
+++ b/tests/plans.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, afterEach, vi } from "vitest";
+import { Effect } from "effect";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as YAML from "yaml";
+import { main } from "../src/app/cli.js";
+import {
+  PlanFilePath,
+  compilePlannedHarnessDocuments,
+  decodePlannedHarnessDocument,
+  decodePromptWorkspacePlanSpec,
+  loadPlannedHarnessPath,
+  runPlannedHarnessPath,
+} from "../src/plans/index.js";
+import { itEffect, EITHER_LEFT, EITHER_RIGHT } from "./support/effect.js";
+
+let capturedPlannedInputs: ReadonlyArray<unknown> | null = null;
+let capturedHarnessRunOpts: Record<string, unknown> | null = null;
+
+vi.mock("../src/app/pipeline.js", () => ({
+  runScenarios: vi.fn(() =>
+    Effect.succeed({
+      runs: [],
+      summary: { total: 0, passed: 0, failed: 0, avgLatencyMs: 0 },
+    })),
+  scoreTraces: vi.fn(() =>
+    Effect.succeed({
+      runs: [],
+      summary: { total: 0, passed: 0, failed: 0, avgLatencyMs: 0 },
+    })),
+  runPlans: vi.fn((inputs: ReadonlyArray<unknown>, opts: Record<string, unknown>) => {
+    capturedPlannedInputs = inputs;
+    capturedHarnessRunOpts = opts;
+    return Effect.succeed({
+      runs: [],
+      summary: { total: inputs.length, passed: inputs.length, failed: 0, avgLatencyMs: 0 },
+    });
+  }),
+}));
+
+const EXIT_SUCCESS = 0;
+const EXIT_FATAL = 2;
+
+function planYaml(overrides: {
+  readonly scenarioId?: string;
+  readonly harnessKind?: string;
+} = {}): string {
+  return YAML.stringify({
+    plan: {
+      project: "cc-judge",
+      scenarioId: overrides.scenarioId ?? "planned-harness-smoke",
+      name: "planned-harness-smoke",
+      description: "exercise planned harness ingress",
+      agents: [
+        {
+          id: "alpha",
+          name: "Alpha",
+          artifact: {
+            _tag: "DockerImageArtifact",
+            image: "repo/alpha:latest",
+          },
+          promptInputs: {},
+        },
+      ],
+      requirements: {
+        expectedBehavior: "complete one prompt",
+        validationChecks: ["summary should be emitted"],
+      },
+    },
+    harness: {
+      kind: overrides.harnessKind ?? "prompt-workspace",
+      config: {
+        prompts: ["Fix the failing test"],
+        workspace: [
+          {
+            path: "README.md",
+            content: "hello",
+          },
+        ],
+        turnTimeoutMs: 1_000,
+      },
+    },
+  });
+}
+
+function writePlanFile(dir: string, name: string, yaml: string): string {
+  const filePath = path.join(dir, name);
+  writeFileSync(filePath, yaml, "utf8");
+  return filePath;
+}
+
+afterEach(() => {
+  capturedPlannedInputs = null;
+  capturedHarnessRunOpts = null;
+});
+
+describe("planned harness schema", () => {
+  itEffect("decodes one planned-harness document from YAML", function* () {
+    const decoded = yield* decodePlannedHarnessDocument(
+      YAML.parse(planYaml()),
+      PlanFilePath("mem://planned-harness.yaml"),
+    );
+
+    expect(decoded.plan.project).toBe("cc-judge");
+    expect(decoded.plan.scenarioId).toBe("planned-harness-smoke");
+    expect(decoded.plan.agents[0].id).toBe("alpha");
+    expect(decoded.harness.kind).toBe("prompt-workspace");
+    expect(decoded.harness.config.prompts).toEqual(["Fix the failing test"]);
+    expect(decoded.harness.config.workspace?.[0]?.path).toBe("README.md");
+    expect(decoded.harness.config.turnTimeoutMs).toBe(1_000);
+  });
+
+  itEffect("rejects non-document roots with TopLevelNotDocument", function* () {
+    const result = yield* Effect.either(
+      decodePlannedHarnessDocument(
+        [YAML.parse(planYaml())],
+        PlanFilePath("mem://array-root.yaml"),
+      ),
+    );
+
+    expect(result._tag).toBe(EITHER_LEFT);
+    if (result._tag === EITHER_LEFT) {
+      expect(result.left.cause._tag).toBe("TopLevelNotDocument");
+      expect(result.left.cause.path).toBe("mem://array-root.yaml");
+    }
+  });
+
+  itEffect("rejects unsupported harness kinds before schema decode", function* () {
+    const result = yield* Effect.either(
+      decodePromptWorkspacePlanSpec(
+        {
+          kind: "arena-game",
+          config: {
+            prompts: ["ignored"],
+          },
+        },
+        PlanFilePath("mem://unsupported.yaml"),
+      ),
+    );
+
+    expect(result._tag).toBe(EITHER_LEFT);
+    if (result._tag === EITHER_LEFT) {
+      expect(result.left.cause._tag).toBe("UnsupportedHarnessKind");
+      expect(result.left.cause.kind).toBe("arena-game");
+    }
+  });
+});
+
+describe("planned harness loader", () => {
+  itEffect("returns FileNotFound for a missing non-glob path", function* () {
+    const result = yield* Effect.either(
+      loadPlannedHarnessPath(path.join(os.tmpdir(), `cc-judge-missing-plan-${Date.now()}.yaml`)),
+    );
+
+    expect(result._tag).toBe(EITHER_LEFT);
+    if (result._tag === EITHER_LEFT) {
+      expect(result.left.cause._tag).toBe("FileNotFound");
+    }
+  });
+
+  itEffect("returns GlobNoMatches for an unmatched glob", function* () {
+    const result = yield* Effect.either(
+      loadPlannedHarnessPath(path.join(os.tmpdir(), "cc-judge-no-plans-*.yaml")),
+    );
+
+    expect(result._tag).toBe(EITHER_LEFT);
+    if (result._tag === EITHER_LEFT) {
+      expect(result.left.cause._tag).toBe("GlobNoMatches");
+    }
+  });
+
+  itEffect("rejects duplicate scenario ids across matched files", function* () {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "cc-judge-plans-dup-"));
+    writePlanFile(dir, "a.yaml", planYaml({ scenarioId: "duplicate-scenario" }));
+    writePlanFile(dir, "b.yaml", planYaml({ scenarioId: "duplicate-scenario" }));
+
+    const result = yield* Effect.either(loadPlannedHarnessPath(path.join(dir, "*.yaml")));
+
+    expect(result._tag).toBe(EITHER_LEFT);
+    if (result._tag === EITHER_LEFT) {
+      expect(result.left.cause._tag).toBe("DuplicateScenarioId");
+      expect(result.left.cause.scenarioId).toBe("duplicate-scenario");
+      expect(result.left.cause.paths[0]).toContain(path.join(dir, "a.yaml"));
+      expect(result.left.cause.paths[1]).toContain(path.join(dir, "b.yaml"));
+    }
+  });
+});
+
+describe("planned harness compiler + cli ingress", () => {
+  itEffect("compiles loaded documents into planned run inputs", function* () {
+    const document = yield* decodePlannedHarnessDocument(
+      YAML.parse(planYaml()),
+      PlanFilePath("mem://compiled.yaml"),
+    );
+
+    const compiled = yield* compilePlannedHarnessDocuments([
+      {
+        sourcePath: PlanFilePath("mem://compiled.yaml"),
+        document,
+      },
+    ]);
+
+    expect(compiled[0]?.sourcePath).toBe("mem://compiled.yaml");
+    expect(compiled[0]?.input.plan.scenarioId).toBe("planned-harness-smoke");
+    expect(compiled[0]?.input.harness.name).toBe("prompt-workspace");
+  });
+
+  itEffect("runs a planned-harness path through the existing runPlans pipeline", function* () {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "cc-judge-plans-run-"));
+    const planPath = writePlanFile(dir, "single.yaml", planYaml());
+    const resultsDir = mkdtempSync(path.join(os.tmpdir(), "cc-judge-plans-out-"));
+
+    const report = yield* runPlannedHarnessPath(planPath, { resultsDir });
+
+    expect(report.summary.total).toBe(1);
+    expect(capturedPlannedInputs).toHaveLength(1);
+    const input = capturedPlannedInputs?.[0] as {
+      readonly plan: { readonly scenarioId: string };
+      readonly harness: { readonly name: string };
+    };
+    expect(input.plan.scenarioId).toBe("planned-harness-smoke");
+    expect(input.harness.name).toBe("prompt-workspace");
+    expect(capturedHarnessRunOpts?.["resultsDir"]).toBe(resultsDir);
+  });
+
+  itEffect("dispatches `run-plans` through the CLI with runtime options", function* () {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "cc-judge-plans-cli-"));
+    const planPath = writePlanFile(dir, "cli.yaml", planYaml());
+    const resultsDir = mkdtempSync(path.join(os.tmpdir(), "cc-judge-plans-cli-out-"));
+
+    const code = yield* main([
+      "run-plans",
+      planPath,
+      "--runtime",
+      "subprocess",
+      "--bin",
+      "/bin/echo",
+      "--results",
+      resultsDir,
+      "--log-level",
+      "error",
+    ]);
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(capturedHarnessRunOpts?.["runtime"]).toMatchObject({ kind: "subprocess" });
+    expect(capturedPlannedInputs).toHaveLength(1);
+  });
+
+  itEffect("returns exit 2 when `run-plans` receives a missing file", function* () {
+    const code = yield* main([
+      "run-plans",
+      path.join(os.tmpdir(), `cc-judge-cli-missing-plan-${Date.now()}.yaml`),
+      "--log-level",
+      "error",
+    ]);
+
+    expect(code).toBe(EXIT_FATAL);
+  });
+});


### PR DESCRIPTION
Spec anchor: https://github.com/chughtapan/moltzap/issues/164
Architecture artifact: https://github.com/chughtapan/moltzap/issues/167
Sub-issue: https://github.com/chughtapan/moltzap/issues/169
Design anchor PR: https://github.com/chughtapan/cc-judge/pull/102

## Summary

This PR is the actual merge candidate for the first `cc-judge` cleanup slice from `moltzap#164` / `#167`.

It is intentionally based on `main` and carries both the architected base and the implementation so it can merge without requiring `#102` to merge first.

Contents:
- freezes the planned-harness contracts from the architect slice
- implements the file-backed planned-harness schema/loader/compiler surface over the existing `runPlans(...)` substrate
- adds the distinct `cc-judge run-plans <planPath>` CLI ingress while leaving the existing simple `run` path unchanged
- exact-pins `effect` to `3.21.0` to align the shared typed surface before downstream MoltZap consumers integrate it
- adds focused decode/load/compile/CLI ingress tests

No compatibility shim was added for the `effect` skew; the merge candidate removes the skew directly at the package boundary.

## Packaging note

`#102` is retained only as the design anchor / architecture artifact reference.
`#103` is the merge path against `main`.

## Traceability

| Artifact in this PR | Kind | Spec anchor | Plan anchor |
|---|---|---|---|
| architected planned-harness contract + design doc | architect base carried in merge candidate | Goal 13 / Goal 17 | `moltzap#167` |
| `package.json`, `pnpm-lock.yaml` exact `effect@3.21.0` | dependency alignment | Goal 1; AC exact `effect` pin before downstream reuse | Dependencies |
| `src/plans/schema.ts` implementation | public surface implementation | Goal 13 / Goal 17 | Modules 1-2; Interfaces; Errors |
| `src/plans/loader.ts` implementation | public surface implementation | Goal 13 / Goal 17 | Module 3; Data flow |
| `src/plans/compiler.ts` implementation | public surface implementation | Goal 7 / Goal 8 / Goal 13 | Module 4; Data flow |
| `src/app/cli.ts` `run-plans` wiring | CLI ingress implementation | Goal 13 | Data flow |
| `tests/plans.test.ts` | verification | Verification for the new ingress slice | Phase 7 |

## Verification

- `pnpm typecheck`
- `pnpm lint`
  Existing repo-wide warning-only baseline remains; no lint errors.
- `pnpm test`
- `pnpm build`

## Workflow notes

- This is a packaging change only; no implementation code changed in response to this task.
- `simplify`: unavailable in this environment, skipped.
- `codex diff review`: unavailable here because the local `codex` CLI does not support the requested review-mode interface.
