### PR TITLE
fix: cache anthropic auth preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,19 @@ npm install -g pnpm
 corepack enable
 ```
 
-### ANTHROPIC_API_KEY
+### Anthropic judge auth
 
-The SDK's `AnthropicJudgeBackend` requires the `ANTHROPIC_API_KEY` environment variable:
+The Anthropic judge path can authenticate in either of these ways:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
+# or
+claude auth login
 ```
 
-This key is used only for judge-backend API calls (Claude model invocations). It is not stored or rotated by cc-judge; manage rotation via your credential provider. The key scope is limited to LLM inference; it cannot modify your Anthropic org or billing.
+`ANTHROPIC_API_KEY` is used only for judge-backend API calls (Claude model invocations). It is not stored or rotated by cc-judge; manage rotation via your credential provider. The key scope is limited to LLM inference; it cannot modify your Anthropic org or billing.
+
+If you use the CLI with `--judge-backend anthropic` and no `ANTHROPIC_API_KEY`, `cc-judge` performs a `claude auth status` preflight before `run`, `run-plans`, or `score`. Successful Claude auth checks are cached for 24 hours in the platform cache directory (`$XDG_CACHE_HOME/cc-judge` when set, otherwise the usual per-user cache directory such as `~/.cache/cc-judge` on Linux) so repeated invocations do not keep re-running the auth probe.
 
 ## Install
 
@@ -61,7 +65,7 @@ The `score` command accepts a single file, a glob pattern, or a directory contai
 - `1` — one or more scenarios failed (judgment failed or agent error)
 - `2` — fatal error (invalid config, missing prerequisites like Docker daemon, schema violation)
 
-Exit code `2` indicates an unrecoverable error (e.g., `DockerRunner` cannot reach the daemon, scenario file is malformed, or `ANTHROPIC_API_KEY` is absent). Exit code `1` indicates that one or more test scenarios ran but the judge marked them as failing.
+Exit code `2` indicates an unrecoverable error (e.g., `DockerRunner` cannot reach the daemon, scenario file is malformed, or Anthropic judge auth is unavailable). Exit code `1` indicates that one or more test scenarios ran but the judge marked them as failing.
 
 ## Scenarios
 

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -26,6 +26,7 @@ import { runScenarios, scoreTraces } from "./pipeline.js";
 import { inspectRun, type InspectErrorCause } from "./inspect.js";
 import { absurd } from "../core/types.js";
 import { runPlannedHarnessPath } from "../plans/compiler.js";
+import { ensureJudgeReady } from "./judge-preflight.js";
 
 export type CliExitCode = 0 | 1 | 2;
 
@@ -471,12 +472,33 @@ export function main(argv: ReadonlyArray<string>): Effect.Effect<CliExitCode, ne
 
     const command = Array.isArray(parsed._) && parsed._.length > 0 ? String(parsed._[0]) : "";
     switch (command) {
-      case "run":
-        return runCommand(parseRunArgs(parsed));
-      case "run-plans":
-        return runPlansCommand(parseRunPlansArgs(parsed));
-      case "score":
-        return scoreCommand(parseScoreArgs(parsed));
+      case "run": {
+        const args = parseRunArgs(parsed);
+        const preflightError = ensureJudgeReady(args.judgeBackend);
+        if (preflightError !== null) {
+          process.stderr.write(`cc-judge: ${preflightError}\n`);
+          return Effect.succeed(2 as CliExitCode);
+        }
+        return runCommand(args);
+      }
+      case "run-plans": {
+        const args = parseRunPlansArgs(parsed);
+        const preflightError = ensureJudgeReady(args.judgeBackend);
+        if (preflightError !== null) {
+          process.stderr.write(`cc-judge: ${preflightError}\n`);
+          return Effect.succeed(2 as CliExitCode);
+        }
+        return runPlansCommand(args);
+      }
+      case "score": {
+        const args = parseScoreArgs(parsed);
+        const preflightError = ensureJudgeReady(args.judgeBackend);
+        if (preflightError !== null) {
+          process.stderr.write(`cc-judge: ${preflightError}\n`);
+          return Effect.succeed(2 as CliExitCode);
+        }
+        return scoreCommand(args);
+      }
       case "inspect":
         return inspectCommand(parseInspectArgs(parsed));
       default:

--- a/src/app/judge-preflight.ts
+++ b/src/app/judge-preflight.ts
@@ -1,0 +1,157 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+interface AnthropicAuthSuccessCache {
+  readonly checkedAtMs: number;
+}
+
+const CLAUDE_PREFLIGHT_TIMEOUT_MS = 5_000;
+const ANTHROPIC_AUTH_CACHE_TTL_MS = 24 * 60 * 60 * 1_000;
+const ANTHROPIC_AUTH_CACHE_FILE = "anthropic-auth-success.json";
+
+let cachedAnthropicAuthSuccessUntilMs: number | null = null;
+
+function shouldPreflightClaudeAuth(judgeBackend: string): boolean {
+  if (judgeBackend !== "anthropic") {
+    return false;
+  }
+  return (process.env["ANTHROPIC_API_KEY"] ?? "").trim().length === 0;
+}
+
+function resolveCacheHome(): string {
+  const xdgCacheHome = (process.env["XDG_CACHE_HOME"] ?? "").trim();
+  if (xdgCacheHome.length > 0) {
+    return xdgCacheHome;
+  }
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Caches");
+  }
+  if (process.platform === "win32") {
+    const localAppData = (process.env["LOCALAPPDATA"] ?? "").trim();
+    if (localAppData.length > 0) {
+      return localAppData;
+    }
+  }
+  return path.join(os.homedir(), ".cache");
+}
+
+function resolveAnthropicAuthCacheDir(): string {
+  return path.join(resolveCacheHome(), "cc-judge");
+}
+
+function resolveAnthropicAuthCachePath(): string {
+  return path.join(resolveAnthropicAuthCacheDir(), ANTHROPIC_AUTH_CACHE_FILE);
+}
+
+function cacheStillFresh(expiresAtMs: number, nowMs: number): boolean {
+  return expiresAtMs > nowMs;
+}
+
+function clearInvalidDiskCache(pathname: string): void {
+  try {
+    rmSync(pathname, { force: true });
+  } catch (error) {
+    void error;
+  }
+}
+
+function readAnthropicAuthCache(nowMs: number): boolean {
+  if (
+    cachedAnthropicAuthSuccessUntilMs !== null &&
+    cacheStillFresh(cachedAnthropicAuthSuccessUntilMs, nowMs)
+  ) {
+    return true;
+  }
+
+  const cachePath = resolveAnthropicAuthCachePath();
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(cachePath, "utf8"));
+    if (typeof parsed !== "object" || parsed === null || !("checkedAtMs" in parsed)) {
+      clearInvalidDiskCache(cachePath);
+      return false;
+    }
+    const checkedAtMs = parsed.checkedAtMs;
+    if (typeof checkedAtMs !== "number" || !Number.isFinite(checkedAtMs)) {
+      clearInvalidDiskCache(cachePath);
+      return false;
+    }
+    const expiresAtMs = checkedAtMs + ANTHROPIC_AUTH_CACHE_TTL_MS;
+    if (!cacheStillFresh(expiresAtMs, nowMs)) {
+      clearInvalidDiskCache(cachePath);
+      return false;
+    }
+    cachedAnthropicAuthSuccessUntilMs = expiresAtMs;
+    return true;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      clearInvalidDiskCache(cachePath);
+    }
+    return false;
+  }
+}
+
+function writeAnthropicAuthCache(nowMs: number): void {
+  const cacheDir = resolveAnthropicAuthCacheDir();
+  const cachePath = resolveAnthropicAuthCachePath();
+  const tempPath = `${cachePath}.${process.pid}.tmp`;
+  const payload: AnthropicAuthSuccessCache = { checkedAtMs: nowMs };
+
+  mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
+  writeFileSync(tempPath, JSON.stringify(payload), "utf8");
+  renameSync(tempPath, cachePath);
+  cachedAnthropicAuthSuccessUntilMs = nowMs + ANTHROPIC_AUTH_CACHE_TTL_MS;
+}
+
+export function ensureJudgeReady(judgeBackend: string): string | null {
+  if (!shouldPreflightClaudeAuth(judgeBackend)) {
+    return null;
+  }
+
+  const nowMs = Date.now();
+  if (readAnthropicAuthCache(nowMs)) {
+    return null;
+  }
+
+  const result = spawnSync("claude", ["auth", "status"], {
+    encoding: "utf8",
+    timeout: CLAUDE_PREFLIGHT_TIMEOUT_MS,
+  });
+
+  if (result.error !== undefined) {
+    return `claude auth preflight failed: ${result.error.message}`;
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim();
+    return stderr.length > 0
+      ? `claude auth preflight failed: ${stderr}`
+      : "claude auth preflight failed";
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(result.stdout);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("loggedIn" in parsed) ||
+      parsed.loggedIn !== true
+    ) {
+      return "claude auth missing: run `claude auth login` or set ANTHROPIC_API_KEY";
+    }
+    writeAnthropicAuthCache(nowMs);
+    return null;
+  } catch (error) {
+    return error instanceof Error
+      ? `claude auth preflight returned invalid JSON: ${error.message}`
+      : "claude auth preflight returned invalid JSON";
+  }
+}
+
+export function resetJudgePreflightCacheForTests(): void {
+  cachedAnthropicAuthSuccessUntilMs = null;
+}
+
+export function clearJudgePreflightDiskCacheForTests(): void {
+  clearInvalidDiskCache(resolveAnthropicAuthCachePath());
+}

--- a/tests/cli-auth-preflight.test.ts
+++ b/tests/cli-auth-preflight.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
+import { mkdtempSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+import { main } from "../src/app/cli.js";
+import {
+  clearJudgePreflightDiskCacheForTests,
+  resetJudgePreflightCacheForTests,
+} from "../src/app/judge-preflight.js";
+import { itEffect } from "./support/effect.js";
+
+const SAVED_XDG_CACHE_HOME = process.env["XDG_CACHE_HOME"];
+const SAVED_ANTHROPIC_API_KEY = process.env["ANTHROPIC_API_KEY"];
+
+function installStderrCapture(): { chunks: string[]; restore: () => void } {
+  const chunks: string[] = [];
+  const original = process.stderr.write.bind(process.stderr);
+  type StderrWriteFn = typeof process.stderr.write;
+  type StderrWritable = { write: StderrWriteFn };
+  const spy: StderrWriteFn = ((value: string | Uint8Array): boolean => {
+    chunks.push(typeof value === "string" ? value : Buffer.from(value).toString("utf8"));
+    return true;
+  }) as StderrWriteFn;
+  (process.stderr as unknown as StderrWritable).write = spy;
+  const restore = (): void => {
+    (process.stderr as unknown as StderrWritable).write = original;
+  };
+  return { chunks, restore };
+}
+
+describe("main anthropic auth preflight", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    resetJudgePreflightCacheForTests();
+    clearJudgePreflightDiskCacheForTests();
+    process.env["XDG_CACHE_HOME"] = mkdtempSync(
+      path.join(os.tmpdir(), "cc-judge-cli-auth-cache-"),
+    );
+    delete process.env["ANTHROPIC_API_KEY"];
+  });
+
+  afterEach(() => {
+    if (SAVED_XDG_CACHE_HOME === undefined) {
+      delete process.env["XDG_CACHE_HOME"];
+    } else {
+      process.env["XDG_CACHE_HOME"] = SAVED_XDG_CACHE_HOME;
+    }
+    if (SAVED_ANTHROPIC_API_KEY === undefined) {
+      delete process.env["ANTHROPIC_API_KEY"];
+    } else {
+      process.env["ANTHROPIC_API_KEY"] = SAVED_ANTHROPIC_API_KEY;
+    }
+  });
+
+  itEffect("fails early with exit 2 when claude auth preflight fails", function* () {
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "not logged in",
+      error: undefined,
+    });
+
+    const { chunks, restore } = installStderrCapture();
+    const code = yield* Effect.ensuring(
+      main(["run", "/tmp/cc-judge-scenario-does-not-matter", "--results", "/tmp/cc-judge-results"]),
+      Effect.sync(restore),
+    );
+
+    expect(code).toBe(2);
+    expect(chunks.join("")).toContain("cc-judge: claude auth preflight failed: not logged in");
+  });
+
+  itEffect("reuses the cached success across repeated CLI invocations", function* () {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ loggedIn: true }),
+      stderr: "",
+      error: undefined,
+    });
+
+    yield* main(["run", "/tmp/cc-judge-scenario-missing", "--results", "/tmp/cc-judge-results-a"]);
+    yield* main(["run", "/tmp/cc-judge-scenario-missing", "--results", "/tmp/cc-judge-results-b"]);
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -14,6 +14,20 @@ import {
 } from "../src/app/cli.js";
 import { itEffect } from "./support/effect.js";
 
+const SAVED_ANTHROPIC_API_KEY = process.env["ANTHROPIC_API_KEY"];
+
+beforeEach(() => {
+  process.env["ANTHROPIC_API_KEY"] = "test-anthropic-api-key";
+});
+
+afterEach(() => {
+  if (SAVED_ANTHROPIC_API_KEY === undefined) {
+    delete process.env["ANTHROPIC_API_KEY"];
+    return;
+  }
+  process.env["ANTHROPIC_API_KEY"] = SAVED_ANTHROPIC_API_KEY;
+});
+
 // ---------------------------------------------------------------------------
 // Mock runScenarios / scoreTraces to capture opts passed from cli.ts.
 // This kills ConditionalExpression, EqualityOperator, and ObjectLiteral

--- a/tests/judge-preflight.test.ts
+++ b/tests/judge-preflight.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+import {
+  clearJudgePreflightDiskCacheForTests,
+  ensureJudgeReady,
+  resetJudgePreflightCacheForTests,
+} from "../src/app/judge-preflight.js";
+
+const SAVED_XDG_CACHE_HOME = process.env["XDG_CACHE_HOME"];
+const SAVED_ANTHROPIC_API_KEY = process.env["ANTHROPIC_API_KEY"];
+
+describe("judge preflight cache", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    resetJudgePreflightCacheForTests();
+    clearJudgePreflightDiskCacheForTests();
+    process.env["XDG_CACHE_HOME"] = mkdtempSync(
+      path.join(os.tmpdir(), "cc-judge-auth-cache-"),
+    );
+    delete process.env["ANTHROPIC_API_KEY"];
+  });
+
+  afterEach(() => {
+    if (SAVED_XDG_CACHE_HOME === undefined) {
+      delete process.env["XDG_CACHE_HOME"];
+    } else {
+      process.env["XDG_CACHE_HOME"] = SAVED_XDG_CACHE_HOME;
+    }
+    if (SAVED_ANTHROPIC_API_KEY === undefined) {
+      delete process.env["ANTHROPIC_API_KEY"];
+    } else {
+      process.env["ANTHROPIC_API_KEY"] = SAVED_ANTHROPIC_API_KEY;
+    }
+  });
+
+  it("skips preflight entirely when ANTHROPIC_API_KEY is set", () => {
+    process.env["ANTHROPIC_API_KEY"] = "test-key";
+
+    expect(ensureJudgeReady("anthropic")).toBeNull();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("caches successful anthropic auth in memory within the same process", () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ loggedIn: true }),
+      stderr: "",
+      error: undefined,
+    });
+
+    expect(ensureJudgeReady("anthropic")).toBeNull();
+    expect(ensureJudgeReady("anthropic")).toBeNull();
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a fresh on-disk success cache after memory reset", () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ loggedIn: true }),
+      stderr: "",
+      error: undefined,
+    });
+
+    expect(ensureJudgeReady("anthropic")).toBeNull();
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+
+    resetJudgePreflightCacheForTests();
+    spawnSyncMock.mockReset();
+
+    expect(ensureJudgeReady("anthropic")).toBeNull();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("does not cache a failing auth preflight", () => {
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "not logged in",
+      error: undefined,
+    });
+
+    expect(ensureJudgeReady("anthropic")).toContain("claude auth preflight failed");
+    expect(ensureJudgeReady("anthropic")).toContain("claude auth preflight failed");
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips anthropic auth preflight for non-anthropic backends", () => {
+    expect(ensureJudgeReady("openai")).toBeNull();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/plans.test.ts
+++ b/tests/plans.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, afterEach, vi } from "vitest";
+import { describe, expect, afterEach, beforeEach, vi } from "vitest";
 import { Effect } from "effect";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import * as os from "node:os";
@@ -17,6 +17,7 @@ import { itEffect, EITHER_LEFT, EITHER_RIGHT } from "./support/effect.js";
 
 let capturedPlannedInputs: ReadonlyArray<unknown> | null = null;
 let capturedHarnessRunOpts: Record<string, unknown> | null = null;
+const SAVED_ANTHROPIC_API_KEY = process.env["ANTHROPIC_API_KEY"];
 
 vi.mock("../src/app/pipeline.js", () => ({
   runScenarios: vi.fn(() =>
@@ -93,6 +94,15 @@ function writePlanFile(dir: string, name: string, yaml: string): string {
 afterEach(() => {
   capturedPlannedInputs = null;
   capturedHarnessRunOpts = null;
+  if (SAVED_ANTHROPIC_API_KEY === undefined) {
+    delete process.env["ANTHROPIC_API_KEY"];
+    return;
+  }
+  process.env["ANTHROPIC_API_KEY"] = SAVED_ANTHROPIC_API_KEY;
+});
+
+beforeEach(() => {
+  process.env["ANTHROPIC_API_KEY"] = "test-anthropic-api-key";
 });
 
 describe("planned harness schema", () => {


### PR DESCRIPTION
## Summary
- add a dedicated Anthropic auth preflight helper for CLI judge readiness
- cache successful `claude auth status` checks for 24 hours in the user cache dir
- keep `cli.ts` wiring narrow while documenting the real auth story in the README

## Why
Repeated `cc-judge run` / `run-plans` / `score` invocations were paying the full `claude auth status` cost every time when using the Anthropic backend without `ANTHROPIC_API_KEY`. That was real CLI overhead, not just a test problem.

## Verification
- `pnpm exec vitest run tests/judge-preflight.test.ts tests/cli-auth-preflight.test.ts`
- `pnpm exec vitest run tests/cli.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm lint` (repo warning baseline only, 0 errors)
