### PR TITLE
fix: stop requiring runtime overrides for harness runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,13 +235,14 @@ Important options:
 
 Compatibility options:
 
-- `--runtime docker|subprocess`
+- `--runtime subprocess`
 - `--bin <path>`
 
 These are only relevant when the loaded harness defers execution to
 `cc-judge`'s built-in coordinator/runtime path. Systems like MoltZap and Arena
 already provide their own coordinator, so the extra runtime flags are usually
-not needed.
+not needed. If you pass `--bin`, `cc-judge` treats that as a subprocess runtime
+override even without `--runtime subprocess`.
 
 ### `score`
 

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -14,7 +14,6 @@ import { BraintrustEmitter, PromptfooEmitter, type ObservabilityEmitter } from "
 import { getTraceAdapter, type TraceFormat } from "../emit/trace-adapter.js";
 import { AnthropicJudgeBackend, JUDGE_SYSTEM_PROMPT } from "../judge/index.js";
 import {
-  DockerRuntime,
   SubprocessRuntime,
   type AgentRuntime,
 } from "../runner/index.js";
@@ -27,8 +26,7 @@ export type CliExitCode = 0 | 1 | 2;
 
 export interface RunCliArgs {
   readonly scenarioPath: string;
-  readonly runtime: "docker" | "subprocess";
-  readonly image?: string;
+  readonly runtime?: "subprocess";
   readonly bin?: string;
   readonly judge: string;
   readonly judgeBackend: string;
@@ -76,18 +74,20 @@ function buildObservability(
   return emitters;
 }
 
-function buildRuntime(args: RunCliArgs): Effect.Effect<AgentRuntime, RunnerResolutionError, never> {
-  if (args.runtime === "subprocess") {
-    if (args.bin === undefined) {
-      return Effect.fail(
-        new RunnerResolutionError({
-          cause: { _tag: "InvalidRuntime", value: "subprocess: missing --bin" },
-        }),
-      );
-    }
-    return Effect.succeed(new SubprocessRuntime({ bin: args.bin }));
+function resolveRuntimeOverride(
+  args: RunCliArgs,
+): Effect.Effect<AgentRuntime | undefined, RunnerResolutionError, never> {
+  if (args.runtime === undefined && args.bin === undefined) {
+    return Effect.succeed(undefined);
   }
-  return Effect.succeed(new DockerRuntime());
+  if (args.bin === undefined) {
+    return Effect.fail(
+      new RunnerResolutionError({
+        cause: { _tag: "InvalidRuntime", value: "subprocess: missing --bin" },
+      }),
+    );
+  }
+  return Effect.succeed(new SubprocessRuntime({ bin: args.bin }));
 }
 
 function printReportSummary(
@@ -99,7 +99,7 @@ function printReportSummary(
 
 function runHarnessPlanCommand(args: RunCliArgs): Effect.Effect<CliExitCode, never, never> {
   return Effect.gen(function* () {
-    const runtimeRes = yield* Effect.either(buildRuntime(args));
+    const runtimeRes = yield* Effect.either(resolveRuntimeOverride(args));
     if (runtimeRes._tag === "Left") {
       const cause = runtimeRes.left.cause;
       const detail = cause._tag === "InvalidRuntime" ? cause.value : cause._tag;
@@ -115,12 +115,12 @@ function runHarnessPlanCommand(args: RunCliArgs): Effect.Effect<CliExitCode, nev
     const emitters = buildObservability(args.emitBraintrust, args.emitPromptfoo);
     const runRes = yield* Effect.either(
       runPlannedHarnessPath(args.scenarioPath, {
-        runtime: runtimeRes.right,
         judge,
         resultsDir: args.results,
         concurrency: args.concurrency,
         emitters,
         logLevel: args.logLevel,
+        ...(runtimeRes.right !== undefined ? { runtime: runtimeRes.right } : {}),
         ...(args.githubComment !== undefined ? { githubComment: args.githubComment } : {}),
         ...(args.githubCommentArtifactUrl !== undefined
           ? { githubCommentArtifactUrl: args.githubCommentArtifactUrl }
@@ -235,7 +235,7 @@ function asObject(raw: unknown): YargsParsed {
 export function parseRunArgs(raw: unknown): RunCliArgs {
   const record = asObject(raw);
   const scenarioPath = typeof record["input"] === "string" ? record["input"] : "";
-  const runtime = record["runtime"] === "subprocess" ? "subprocess" : "docker";
+  const runtime = record["runtime"] === "subprocess" ? "subprocess" : undefined;
   const logLevel = (
     record["logLevel"] === "debug" ||
     record["logLevel"] === "info" ||
@@ -246,8 +246,7 @@ export function parseRunArgs(raw: unknown): RunCliArgs {
     : "info";
   return {
     scenarioPath,
-    runtime,
-    ...(typeof record["image"] === "string" ? { image: record["image"] } : {}),
+    ...(runtime !== undefined ? { runtime } : {}),
     ...(typeof record["bin"] === "string" ? { bin: record["bin"] } : {}),
     judge: typeof record["judge"] === "string" ? record["judge"] : "claude-opus-4-7",
     judgeBackend: typeof record["judgeBackend"] === "string" ? record["judgeBackend"] : "anthropic",
@@ -336,8 +335,7 @@ export function main(argv: ReadonlyArray<string>): Effect.Effect<CliExitCode, ne
       .command("run <input>", "Run harness-backed plans", (yargsBuilder) =>
         yargsBuilder
           .positional("input", { type: "string", demandOption: true })
-          .option("runtime", { choices: ["docker", "subprocess"] as const, default: "docker" })
-          .option("image", { type: "string" })
+          .option("runtime", { choices: ["subprocess"] as const })
           .option("bin", { type: "string" })
           .option("judge", { type: "string", default: "claude-opus-4-7" })
           .option("judge-backend", { type: "string", default: "anthropic" })

--- a/tests/cli-auth-preflight.test.ts
+++ b/tests/cli-auth-preflight.test.ts
@@ -32,9 +32,10 @@ import {
   resetJudgePreflightCacheForTests,
 } from "../src/app/judge-preflight.js";
 import { itEffect } from "./support/effect.js";
+import { captureEnvVar, restoreEnvVar } from "./support/env.js";
 
-const SAVED_XDG_CACHE_HOME = process.env["XDG_CACHE_HOME"];
-const SAVED_ANTHROPIC_API_KEY = process.env["ANTHROPIC_API_KEY"];
+const SAVED_XDG_CACHE_HOME = captureEnvVar("XDG_CACHE_HOME");
+const SAVED_ANTHROPIC_API_KEY = captureEnvVar("ANTHROPIC_API_KEY");
 
 function writeHarnessPlan(dir: string, fileName: string): string {
   const modulePath = path.join(dir, "fixture-harness.mjs");
@@ -119,16 +120,8 @@ describe("main anthropic auth preflight", () => {
   });
 
   afterEach(() => {
-    if (SAVED_XDG_CACHE_HOME === undefined) {
-      delete process.env["XDG_CACHE_HOME"];
-    } else {
-      process.env["XDG_CACHE_HOME"] = SAVED_XDG_CACHE_HOME;
-    }
-    if (SAVED_ANTHROPIC_API_KEY === undefined) {
-      delete process.env["ANTHROPIC_API_KEY"];
-    } else {
-      process.env["ANTHROPIC_API_KEY"] = SAVED_ANTHROPIC_API_KEY;
-    }
+    restoreEnvVar("XDG_CACHE_HOME", SAVED_XDG_CACHE_HOME);
+    restoreEnvVar("ANTHROPIC_API_KEY", SAVED_ANTHROPIC_API_KEY);
   });
 
   itEffect("fails early with exit 2 when claude auth preflight fails", function* () {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -79,7 +79,6 @@ function tmpScenarioDir(): string {
 function baseArgs(scenarioDir: string): RunCliArgs {
   return {
     scenarioPath: scenarioDir,
-    runtime: "docker",
     judge: "claude-opus-4-7",
     judgeBackend: "anthropic",
     results: mkdtempSync(path.join(os.tmpdir(), "cc-judge-cli-out-")),
@@ -134,8 +133,6 @@ describe("main (yargs dispatch)", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime",
-      "docker",
       "--results",
       results,
       "--log-level",
@@ -187,8 +184,6 @@ describe("main (yargs dispatch)", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime",
-      "docker",
       "--judge",
       "claude-sonnet-4-6",
       "--judge-backend",
@@ -210,14 +205,13 @@ describe("parseRunArgs", () => {
   it("supplies defaults for every optional field when raw is empty", () => {
     const args = parseRunArgs({});
     expect(args.scenarioPath).toBe("");
-    expect(args.runtime).toBe("docker");
+    expect(args.runtime).toBeUndefined();
     expect(args.judge).toBe("claude-opus-4-7");
     expect(args.judgeBackend).toBe("anthropic");
     expect(args.results).toBe("./eval-results");
     expect(args.concurrency).toBe(1);
     expect(args.logLevel).toBe("info");
     expect(args.emitBraintrust).toBe(false);
-    expect(args.image).toBeUndefined();
     expect(args.bin).toBeUndefined();
     expect(args.githubComment).toBeUndefined();
     expect(args.githubCommentArtifactUrl).toBeUndefined();
@@ -232,11 +226,10 @@ describe("parseRunArgs", () => {
     expect(parseRunArgs([]).scenarioPath).toBe("");
   });
 
-  it("passes through string input + image + bin when provided", () => {
+  it("passes through string input + runtime + bin when provided", () => {
     const args = parseRunArgs({
       input: "/path/to/s",
       runtime: "subprocess",
-      image: "my-img",
       bin: "/usr/bin/claude",
       judge: "claude-custom",
       judgeBackend: "openai",
@@ -251,7 +244,6 @@ describe("parseRunArgs", () => {
     });
     expect(args.scenarioPath).toBe("/path/to/s");
     expect(args.runtime).toBe("subprocess");
-    expect(args.image).toBe("my-img");
     expect(args.bin).toBe("/usr/bin/claude");
     expect(args.judge).toBe("claude-custom");
     expect(args.judgeBackend).toBe("openai");
@@ -265,10 +257,10 @@ describe("parseRunArgs", () => {
     expect(args.emitPromptfoo).toBe("/p.json");
   });
 
-  it("normalizes runtime to docker when value is neither docker nor subprocess", () => {
-    expect(parseRunArgs({ runtime: "wasm" }).runtime).toBe("docker");
-    expect(parseRunArgs({ runtime: null }).runtime).toBe("docker");
-    expect(parseRunArgs({ runtime: "" }).runtime).toBe("docker");
+  it("drops runtime override when value is neither docker nor subprocess", () => {
+    expect(parseRunArgs({ runtime: "wasm" }).runtime).toBeUndefined();
+    expect(parseRunArgs({ runtime: null }).runtime).toBeUndefined();
+    expect(parseRunArgs({ runtime: "" }).runtime).toBeUndefined();
   });
 
   it("normalizes logLevel to info when value is not one of the four accepted levels", () => {
@@ -284,16 +276,14 @@ describe("parseRunArgs", () => {
     expect(parseRunArgs({ logLevel: "error" }).logLevel).toBe("error");
   });
 
-  it("drops image / bin / githubComment when the wrong type", () => {
+  it("drops bin / githubComment when the wrong type", () => {
     const args = parseRunArgs({
-      image: 42,
       bin: null,
       githubComment: "not-a-number",
       githubCommentArtifactUrl: 99,
       totalTimeoutMs: "not-a-number",
       emitPromptfoo: 100,
     });
-    expect(args.image).toBeUndefined();
     expect(args.bin).toBeUndefined();
     expect(args.githubComment).toBeUndefined();
     expect(args.githubCommentArtifactUrl).toBeUndefined();
@@ -411,8 +401,6 @@ const STUB_PROMPTFOO_OUTPUT = "/tmp/cc-judge-promptfoo-stub.json";
 function stubRunArgs(scenarioDir: string, overrides: Partial<RunCliArgs> = {}): RunCliArgs {
   return {
     scenarioPath: scenarioDir,
-    runtime: "subprocess",
-    bin: BIN_TRUE,
     judge: "claude-opus-4-7",
     judgeBackend: "anthropic",
     results: mkdtempSync(path.join(os.tmpdir(), "cc-judge-stub-out-")),
@@ -742,14 +730,12 @@ describe("parseRunArgs logLevel each position in OR chain", () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe("main (yargs) option names and defaults", () => {
-  itEffect("run subcommand accepts a harness input path", function* () {
+  itEffect("run subcommand accepts a harness input path without a runtime override", function* () {
     const dir = tmpScenarioDir();
     const results = mkdtempSync(path.join(os.tmpdir(), "cc-judge-main-si-"));
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--results", results,
       "--log-level", "error",
     ]);
@@ -762,8 +748,6 @@ describe("main (yargs) option names and defaults", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--github-comment", "1",
       "--results", results,
       "--log-level", "error",
@@ -777,8 +761,6 @@ describe("main (yargs) option names and defaults", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--github-comment-artifact-url", "https://example.com/art",
       "--results", results,
       "--log-level", "error",
@@ -792,8 +774,6 @@ describe("main (yargs) option names and defaults", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--total-timeout-ms", "60000",
       "--results", results,
       "--log-level", "error",
@@ -807,8 +787,6 @@ describe("main (yargs) option names and defaults", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--results", results,
       "--log-level", "error",
     ]);
@@ -821,8 +799,6 @@ describe("main (yargs) option names and defaults", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--emit-promptfoo", STUB_PROMPTFOO_OUTPUT,
       "--results", results,
       "--log-level", "error",
@@ -836,8 +812,6 @@ describe("main (yargs) option names and defaults", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--concurrency", "1",
       "--results", results,
       "--log-level", "debug",
@@ -851,8 +825,6 @@ describe("main (yargs) option names and defaults", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--results", results,
       "--log-level", "info",
     ]);
@@ -1004,33 +976,12 @@ describe("main (yargs) option names and defaults", () => {
     expect(code).toBe(EXIT_FATAL);
   });
 
-  itEffect("run subcommand: --image option name resolves", function* () {
-    const dir = tmpScenarioDir();
-    const results = mkdtempSync(path.join(os.tmpdir(), "cc-judge-main-img-"));
-    // With --runtime docker + --image set, runner resolves but start() will fail
-    // (no docker available in test env). Exit 0 or 1 is acceptable.
-    const { restore } = installStderrCapture();
-    const code = yield* Effect.ensuring(
-      main([
-        "run",
-        dir,
-        "--runtime", "docker",
-        "--image", "cc-judge-nonexistent-image-xyz",
-        "--results", results,
-        "--log-level", "error",
-      ]),
-      Effect.sync(restore),
-    );
-    expect(code).toBe(EXIT_SUCCESS);
-  });
-
   itEffect("run subcommand: --bin option name resolves", function* () {
     const dir = tmpScenarioDir();
     const results = mkdtempSync(path.join(os.tmpdir(), "cc-judge-main-bin-"));
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
       "--bin", BIN_TRUE,
       "--results", results,
       "--log-level", "error",
@@ -1077,8 +1028,6 @@ describe("main (yargs) option names and defaults", () => {
     const code = yield* main([
       "run",
       dir,
-      "--runtime", "subprocess",
-      "--bin", BIN_TRUE,
       "--results", results,
       "--log-level", "warn",
     ]);
@@ -1102,7 +1051,7 @@ describe("main (yargs) option names and defaults", () => {
     expect(code).toBe(EXIT_FATAL);
   });
 
-  itEffect("run: --runtime subprocess (default docker changed to subprocess)", function* () {
+  itEffect("run: --runtime subprocess selects the subprocess runtime override", function* () {
     const dir = tmpScenarioDir();
     const results = mkdtempSync(path.join(os.tmpdir(), "cc-judge-main-rt-"));
     const code = yield* main([
@@ -1292,17 +1241,25 @@ describe("runCommand passes optional opts to the harness run path (mock capture)
     expect(capturedRunOpts!["totalTimeoutMs"]).toBeUndefined();
   });
 
-  itEffect("base fields (runtime, judge, resultsDir, concurrency, logLevel, emitters) are always present", function* () {
+  itEffect("base fields (judge, resultsDir, concurrency, logLevel, emitters) are always present", function* () {
     const dir = tmpScenarioDir();
     const args = stubRunArgs(dir);
     yield* runCommand(args);
     expect(capturedRunOpts).not.toBeNull();
-    expect(capturedRunOpts!["runtime"]).toBeDefined();
+    expect(capturedRunOpts!["runtime"]).toBeUndefined();
     expect(capturedRunOpts!["judge"]).toBeDefined();
     expect(capturedRunOpts!["resultsDir"]).toBeDefined();
     expect(capturedRunOpts!["concurrency"]).toBeDefined();
     expect(capturedRunOpts!["logLevel"]).toBe(MOCK_LOG_LEVEL_ERROR);
     expect(capturedRunOpts!["emitters"]).toBeDefined();
+  });
+
+  itEffect("explicit subprocess runtime override is forwarded when runtime and bin are provided", function* () {
+    const dir = tmpScenarioDir();
+    const args = stubRunArgs(dir, { runtime: "subprocess", bin: BIN_TRUE });
+    yield* runCommand(args);
+    expect(capturedRunOpts).not.toBeNull();
+    expect(capturedRunOpts!["runtime"]).toMatchObject({ kind: "subprocess" });
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -13,20 +13,9 @@ import {
   type ScoreCliArgs,
 } from "../src/app/cli.js";
 import { itEffect } from "./support/effect.js";
+import { installDefaultEnvVar } from "./support/env.js";
 
-const SAVED_ANTHROPIC_API_KEY = process.env["ANTHROPIC_API_KEY"];
-
-beforeEach(() => {
-  process.env["ANTHROPIC_API_KEY"] = "test-anthropic-api-key";
-});
-
-afterEach(() => {
-  if (SAVED_ANTHROPIC_API_KEY === undefined) {
-    delete process.env["ANTHROPIC_API_KEY"];
-    return;
-  }
-  process.env["ANTHROPIC_API_KEY"] = SAVED_ANTHROPIC_API_KEY;
-});
+installDefaultEnvVar("ANTHROPIC_API_KEY", "test-anthropic-api-key");
 
 // ---------------------------------------------------------------------------
 // Mock harness-plan execution / scoreTraces to capture opts passed from cli.ts.

--- a/tests/judge-preflight.test.ts
+++ b/tests/judge-preflight.test.ts
@@ -16,9 +16,10 @@ import {
   ensureJudgeReady,
   resetJudgePreflightCacheForTests,
 } from "../src/app/judge-preflight.js";
+import { captureEnvVar, restoreEnvVar } from "./support/env.js";
 
-const SAVED_XDG_CACHE_HOME = process.env["XDG_CACHE_HOME"];
-const SAVED_ANTHROPIC_API_KEY = process.env["ANTHROPIC_API_KEY"];
+const SAVED_XDG_CACHE_HOME = captureEnvVar("XDG_CACHE_HOME");
+const SAVED_ANTHROPIC_API_KEY = captureEnvVar("ANTHROPIC_API_KEY");
 
 describe("judge preflight cache", () => {
   beforeEach(() => {
@@ -32,16 +33,8 @@ describe("judge preflight cache", () => {
   });
 
   afterEach(() => {
-    if (SAVED_XDG_CACHE_HOME === undefined) {
-      delete process.env["XDG_CACHE_HOME"];
-    } else {
-      process.env["XDG_CACHE_HOME"] = SAVED_XDG_CACHE_HOME;
-    }
-    if (SAVED_ANTHROPIC_API_KEY === undefined) {
-      delete process.env["ANTHROPIC_API_KEY"];
-    } else {
-      process.env["ANTHROPIC_API_KEY"] = SAVED_ANTHROPIC_API_KEY;
-    }
+    restoreEnvVar("XDG_CACHE_HOME", SAVED_XDG_CACHE_HOME);
+    restoreEnvVar("ANTHROPIC_API_KEY", SAVED_ANTHROPIC_API_KEY);
   });
 
   it("skips preflight entirely when ANTHROPIC_API_KEY is set", () => {

--- a/tests/plans.test.ts
+++ b/tests/plans.test.ts
@@ -295,7 +295,7 @@ describe("planned harness compiler + cli ingress", () => {
     const { chunks, restore } = installStderrCapture();
 
     const code = yield* Effect.ensuring(
-      main(["run", badPath, "--runtime", "subprocess", "--bin", "/bin/echo", "--log-level", "error"]),
+      main(["run", badPath, "--log-level", "error"]),
       Effect.sync(restore),
     );
 

--- a/tests/plans.test.ts
+++ b/tests/plans.test.ts
@@ -13,6 +13,9 @@ import {
   runPlannedHarnessPath,
 } from "../src/plans/index.js";
 import { itEffect, EITHER_LEFT } from "./support/effect.js";
+import { installDefaultEnvVar } from "./support/env.js";
+
+installDefaultEnvVar("ANTHROPIC_API_KEY", "test-anthropic-api-key");
 
 let capturedPlannedInputs: ReadonlyArray<unknown> | null = null;
 let capturedHarnessRunOpts: Record<string, unknown> | null = null;

--- a/tests/support/env.ts
+++ b/tests/support/env.ts
@@ -1,0 +1,23 @@
+import { afterEach, beforeEach } from "vitest";
+
+export function restoreEnvVar(name: string, savedValue: string | undefined): void {
+  if (savedValue === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = savedValue;
+}
+
+export function installDefaultEnvVar(name: string, value: string): void {
+  const savedValue = process.env[name];
+  beforeEach(() => {
+    process.env[name] = value;
+  });
+  afterEach(() => {
+    restoreEnvVar(name, savedValue);
+  });
+}
+
+export function captureEnvVar(name: string): string | undefined {
+  return process.env[name];
+}


### PR DESCRIPTION
## Summary
- stop requiring dummy runtime flags for harness-backed `cc-judge run`
- remove the dead docker/image compat surface from the run CLI
- update README and CLI tests to match the harness-first flow

## What changed
- `run` now omits any runtime override unless the caller explicitly requests subprocess via `--runtime subprocess` or provides `--bin`
- `--bin` now implies the subprocess override instead of forcing `--runtime subprocess`
- removed the old `docker` / `--image` run-path options from the public CLI surface
- updated docs and tests accordingly

## Verification
- `pnpm exec vitest run tests/cli.test.ts tests/plans.test.ts tests/cli-auth-preflight.test.ts`
- `pnpm typecheck`
- real dogfood:
  - `node dist/bin.js run /home/tapanc/moltzap-worker-i-179/packages/evals/scenarios/EVAL-005.yaml --results /tmp/ccj-no-runtime-override --log-level info --total-timeout-ms 60000`
  - confirmed the MoltZap harness boots, registers agents, creates the DM, and runs without any `--runtime` / `--image` flags
  - later exits on the existing bounded judge abort path (`Operation aborted`), which is separate from this CLI debt cleanup
